### PR TITLE
Fix: No se registraban las tareas como ya ejecutadas del scheduler de subvenciones

### DIFF
--- a/etl/cli.py
+++ b/etl/cli.py
@@ -1354,19 +1354,76 @@ def cmd_subvenciones(args: argparse.Namespace) -> int:
         return 1
 
     if subv_cmd == "diario":
+        # Register scheduler run (same pattern as cmd_ingest)
+        run_id = None
+        db_url = get_database_url()
+        subv_result = [
+            "failed",
+            0,
+            0,
+            None,
+        ]  # status, rows_inserted, rows_omitted, error_msg
+
+        if db_url:
+            try:
+                from etl.scheduler import (
+                    get_task_id,
+                    has_running_run,
+                    insert_run_start,
+                    update_run_process_id,
+                )
+
+                with psycopg2.connect(db_url) as conn:
+                    conn.autocommit = False
+                    task_id = get_task_id(conn, "nacional", "subvenciones")
+                    if task_id and has_running_run(conn, task_id):
+                        print(
+                            "[subvenciones] Ya hay una ejecución en curso para esta tarea (scheduler).",
+                            file=sys.stderr,
+                        )
+                        return 1
+                    if task_id:
+                        run_id = insert_run_start(conn, task_id)
+                        update_run_process_id(conn, run_id, os.getpid())
+                        conn.commit()
+            except (ImportError, psycopg2.Error, Exception):
+                run_id = None
+
         try:
             sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
             from nacional.subvenciones import scrape_diario, LatestParams
 
             params = LatestParams(page=0, pageSize=100)
-            scrape_diario(params)
+            result = scrape_diario(params)
+            subv_result[0] = "ok"
+            subv_result[1] = result.get("inserted", 0)
+            subv_result[2] = result.get("omitted", 0)
             return 0
         except Exception as e:
+            subv_result[3] = str(e)
             print(
                 f"[ERROR] Error en actualización diaria de subvenciones: {e}",
                 file=sys.stderr,
             )
             return 1
+        finally:
+            # Update scheduler run status
+            if run_id and db_url:
+                try:
+                    from etl.scheduler import update_run_finish
+
+                    with psycopg2.connect(db_url) as conn:
+                        update_run_finish(
+                            conn,
+                            run_id,
+                            subv_result[0] or "failed",
+                            subv_result[1],
+                            subv_result[2],
+                            subv_result[3],
+                        )
+                        conn.commit()
+                except Exception:
+                    pass
     else:
         print("Subcomando subvenciones no reconocido.", file=sys.stderr)
         return 1

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -17,6 +17,7 @@ LOG_PREFIX = "[subvenciones]"
 def _log(level: str, msg: str) -> None:
     print(f"{LOG_PREFIX} [{level}] {msg}", flush=True)
 
+
 # Add parent directory to path to import etl modules
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from etl.config import get_database_url
@@ -68,7 +69,10 @@ class RateLimiter:
             wait_time = self.time_window - (now - oldest_request)
 
             if wait_time > 0:
-                _log("WARN", f"Límite de peticiones alcanzado. Esperando {wait_time:.1f}s...")
+                _log(
+                    "WARN",
+                    f"Límite de peticiones alcanzado. Esperando {wait_time:.1f}s...",
+                )
                 time.sleep(wait_time + 0.1)
                 now = time.time()
                 self.request_times = [
@@ -212,7 +216,10 @@ def scrape_historico(params: SearchParams) -> Path:
 
             if page == 0:
                 total_elements = data.get("totalElements", 0)
-                _log("INFO", f"Total registros en API: {total_elements:,} ({total_pages} páginas)")
+                _log(
+                    "INFO",
+                    f"Total registros en API: {total_elements:,} ({total_pages} páginas)",
+                )
 
             if not content:
                 _log("WARN", f"Página {page + 1} vacía — fin de datos")
@@ -262,7 +269,7 @@ def scrape_historico(params: SearchParams) -> Path:
         raise
 
 
-def scrape_diario(params: LatestParams) -> None:
+def scrape_diario(params: LatestParams) -> dict[str, int]:
     """
     Scrape latest/daily grants and insert directly into database.
     This is for daily scheduler updates - small volume so direct insert is efficient.
@@ -271,7 +278,7 @@ def scrape_diario(params: LatestParams) -> None:
         params: LatestParams for latest updates
 
     Returns:
-        Total number of new records inserted
+        Dictionary with metrics: inserted, omitted, filtered, pages
     """
     params.validate()
 
@@ -285,12 +292,11 @@ def scrape_diario(params: LatestParams) -> None:
     total_new = 0
     total_duplicates = 0
     total_filtered = 0
-    pages_scanned = 0
     rate_limiter = RateLimiter(max_requests=49, time_window=60)
     subvencion_pattern = re.compile(r"subvenci[oó]n", re.IGNORECASE)
 
     print(f"\n{'='*60}", flush=True)
-    print(f"📦 SUBVENCIONES DIARIAS (BDNS)", flush=True)
+    print(f"SUBVENCIONES DIARIAS (BDNS)", flush=True)
     print(f"   Endpoint: {API_ENDPOINT_LATEST}", flush=True)
     print(f"   Modo: insert directo en BD", flush=True)
     print(f"{'='*60}", flush=True)
@@ -328,7 +334,6 @@ def scrape_diario(params: LatestParams) -> None:
             total_pages = data.get("totalPages", "?")
 
             if not content:
-                _log("INFO", f"Página {page + 1} vacía — fin de datos")
                 break
 
             page_filtered = 0
@@ -355,13 +360,7 @@ def scrape_diario(params: LatestParams) -> None:
             total_filtered += page_filtered
 
             if not records:
-                _log(
-                    "INFO",
-                    f"Página {page + 1}/{total_pages} — {len(content)} convocatorias, "
-                    f"0 subvenciones (filtradas {page_filtered})",
-                )
                 page += 1
-                pages_scanned += 1
                 continue
 
             with conn.cursor() as cur:
@@ -390,31 +389,19 @@ def scrape_diario(params: LatestParams) -> None:
                     conn.commit()
                     total_new += len(new_records)
 
-                _log(
-                    "INFO",
-                    f"Página {page + 1}/{total_pages} — "
-                    f"{len(new_records)} nuevos, {page_dups} ya existentes"
-                    + (f", {page_filtered} filtrados" if page_filtered else ""),
-                )
-
                 if existing_ids:
-                    _log(
-                        "INFO",
-                        f"Detectados {page_dups} registros ya existentes — "
-                        f"datos actualizados, deteniendo paginación",
-                    )
-                    pages_scanned += 1
                     break
 
             page += 1
-            pages_scanned += 1
 
-        print(f"\n✅ SCRAPING COMPLETADO: subvenciones diarias", flush=True)
-        _log("INFO", f"Páginas consultadas: {pages_scanned}")
-        _log("INFO", f"Registros nuevos insertados: {total_new:,}")
-        _log("INFO", f"Registros ya existentes (omitidos): {total_duplicates:,}")
-        if total_filtered:
-            _log("INFO", f"Convocatorias no-subvención filtradas: {total_filtered:,}")
+        print(f"\nSCRAPING COMPLETADO: subvenciones diarias", flush=True)
+
+        return {
+            "inserted": total_new,
+            "omitted": total_duplicates,
+            "filtered": total_filtered,
+            "pages": page + 1,
+        }
 
     except Exception as err:
         print(f"\n❌ ERROR: scraping diario falló", flush=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ pytest>=7.0.0
 tqdm>=4.65.0
 python-dateutil>=2.9.0
 beautifulsoup4>=4.12.0
+fastapi>=0.100.0
+uvicorn[standard]>=0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,3 @@ pytest>=7.0.0
 tqdm>=4.65.0
 python-dateutil>=2.9.0
 beautifulsoup4>=4.12.0
-fastapi>=0.100.0
-uvicorn[standard]>=0.22.0


### PR DESCRIPTION
## Summary
Qué cambió:
- `nacional/subvenciones.py`: `scrape_diario()` ahora devuelve dict con métricas en lugar de None
- `etl/cli.py`: `cmd_subvenciones()` ahora registra ejecuciones en tabla `scheduler.runs`
- Añadido ciclo de vida de ejecución: `insert_run_start()`, `update_run_process_id()`, `update_run_finish()`
- Añadida prevención de ejecuciones duplicadas con verificación `has_running_run()`

Por qué:
El comando subvenciones no registraba sus ejecuciones en la tabla scheduler.runs. Sin actualizar `last_finished_at`, el scheduler consideraba la tarea siempre pendiente y la ejecutaba cada 60 segundos en lugar de respetar la programación diaria (2:00 AM).

## Linked Issue (required)
Closes #26

## Validation
- [ ] Relevant tests pass locally
- [ ] Lint/format checks pass
- [ ] Manual verification completed:
  - [ ] Ejecutar `licitia-etl scheduler register` correctamente
  - [ ] Ejecutar `licitia-etl scheduler run` y verificar que subvenciones se ejecuta solo una vez
  - [ ] Verificar que `licitia-etl scheduler status` muestra última ejecución correcta
  - [ ] Verificar que tabla `scheduler.runs` contiene registros de ejecución con métricas

<img width="1302" height="862" alt="image" src="https://github.com/user-attachments/assets/faa98695-bf07-4dfc-b9c4-b641d1526b10" />

## Risk and Rollback
- Risk level: Low

Justificación:
- Cambio aislado al flujo de ejecución del comando subvenciones
- Cambio a la función y afecta solo llamada interna CLI (verificado sin uso externo)
- Sin cambios en modelo de datos, solo añade registros a tabla scheduler.runs existente
- No modifica datos existentes, solo tracking de ejecuciones.

Rollback plan:
1. Revertir commits de esta PR
2. Re-desplegar versión anterior
3. Scheduler continuará funcionando como antes (subvenciones se ejecutará manualmente o se omitirá hasta resolver)
4. No requiere rollback de base de datos (registros scheduler.runs son metadata no crítica)