### PR TITLE
fix: align v1.5.0 — filename mismatch 014, version bump, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Todos los cambios notables del CLI y del microservicio ETL se documentan aquí.
 
+## [1.5.0] — 2026-04-17
+
+### Añadido
+
+- **Tablas dimensionales de órganos gestores:** 4 nuevas tablas en el esquema `dim` para entidades administrativas de nivel 3 — comunidades autónomas (`dim.organos_gestores_ccaa`), ministerios (`dim.ministerios_organos`), provincias (`dim.provincias_organos`) y otros órganos (`dim.otros_organos`). Datos estáticos pre-cargados vía migraciones `014`–`017`.
+- **Tablas dimensionales de subvenciones:** 3 nuevas tablas — beneficiarios (`dim.beneficiarios_subvenciones`), instrumentos (`dim.instrumentos_subvenciones`) y política de gastos (`dim.politica_gastos`). Migraciones `018`–`020`.
+
+### Corregido
+
+- **`INIT_MIGRATIONS` — nombre de fichero 014 desalineado:** `cli.py` referenciaba `014_dim_organos_gestores_ccaa.sql` pero el fichero real es `014_dim_ccaa_organos.sql`, lo que impedía que la migración se aplicase durante `init-db`.
+
+---
+
 ## [1.4.1] — 2026-04-08
 
 ### Mejorado

--- a/etl/__init__.py
+++ b/etl/__init__.py
@@ -5,4 +5,4 @@ Punto de entrada CLI: licitia-etl
 Comandos: status, init-db, ingest, health, scheduler, db-info.
 """
 
-__version__ = "1.4.1"
+__version__ = "1.5.0"

--- a/etl/cli.py
+++ b/etl/cli.py
@@ -47,7 +47,7 @@ INIT_MIGRATIONS = (
     "011_nacional_new_columns.sql",
     "012_nacional_subvenciones.sql",
     "013_dim_cnae.sql",
-    "014_dim_organos_gestores_ccaa.sql",
+    "014_dim_ccaa_organos.sql",
     "015_dim_ministerios_organos.sql",
     "016_dim_provincias_organos.sql",
     "017_dim_otros_organos.sql",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "licitaciones-etl"
-version = "1.4.1"
+version = "1.5.0"
 description = "ETL microservice CLI for licitaciones-espana (schemas, init-db, ingest, scheduler)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Hotfix for v1.5.0 release (#32):

- **014 filename mismatch**: `INIT_MIGRATIONS` in `cli.py` referenced `014_dim_organos_gestores_ccaa.sql` but the actual migration file is `014_dim_ccaa_organos.sql`. This prevented the CCAA órganos gestores migration from being applied during `init-db`.
- **Version bump**: `__init__.py` and `pyproject.toml` still pointed to `1.4.1`. Updated to `1.5.0`.
- **Changelog**: Added `[1.5.0]` section documenting the 7 new dimensional tables.

## Test plan

- [ ] Verify `licitia-etl init-db` applies all 7 new migrations (014–020)
- [ ] Verify `licitia-etl health` returns correct migration status

Made with [Cursor](https://cursor.com)