### PR TITLE
Migración a ingesta completa de datos de subvenciones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,85 @@
 
 Todos los cambios notables del CLI y del microservicio ETL se documentan aquí.
 
+## [1.5.2] — 2026-04-21
+
+### Resumen
+
+- **Ingesta completa de datos de subvenciones:** migración de 6 a 32 campos por convocatoria, guardando TODOS los datos detallados (instrumentos, beneficiarios, sectores, regiones, presupuesto, documentos, anuncios) en lugar de solo datos ligeros.
+- **Nueva arquitectura de scraping en 2 fases:** fase 1 obtiene IDs ligeros (`/busqueda`), fase 2 obtiene detalles completos por cada ID (`/convocatorias`).
+- **Optimizaciones de rendimiento:** rate limiting adaptativo global thread-safe, multithreading producer-consumer para scraping histórico, carga paralela de parquets, consulta optimizada 250x más rápida.
+- **Eliminación de dependencia API externa:** con datos completos en BD, Licitia ya no necesita llamar a API externa para obtener detalles de subvenciones.
+
+### Añadido
+
+- **`nacional/subvenciones.py`:**
+  - Nueva función `fetch_convocatoria_detalle()`: obtiene información completa de una convocatoria desde endpoint de detalle con rate limiting adaptativo.
+  - Funciones helper `_flatten_organo()` y `_convert_to_json_serializable()` para procesamiento de datos.
+  - Rate limiting adaptativo global con `_api_delay_seconds` y `_api_delay_lock` (thread-safe).
+  - Pattern producer-consumer en `scrape_historico`: thread fetcher obtiene detalles y pone en Queue, thread saver consume Queue y genera parquets por batches.
+  - Campo `direccion` en `SearchParams`: `"asc"` para histórico, `"desc"` para diario.
+
+- **`etl/cli.py`:**
+  - Soporte ThreadPool (3 workers) para carga paralela de múltiples parquets de subvenciones.
+  - Solo activo para `nacional/subvenciones` con múltiples archivos parquet.
+
+- **`schemas/012_nacional_subvenciones.sql`:**
+  - 26 campos nuevos: `sede_electronica`, `tipo_convocatoria`, `presupuesto_total`.
+  - 10 arrays JSONB: `instrumentos`, `tipos_beneficiarios`, `sectores`, `regiones`, `fondos`, `reglamento`, `objetivos`, `sectores_productos`, `documentos`, `anuncios`.
+  - Campos de bases reguladoras: `descripcion_finalidad`, `descripcion_bases_reguladoras`, `url_bases_reguladoras`.
+  - Estado y fechas: `abierto`, `se_publica_diario_oficial`, `fecha_inicio_solicitud`, `fecha_fin_solicitud`, `text_inicio`, `text_fin`.
+  - Ayuda de estado: `ayuda_estado`, `url_ayuda_estado`.
+
+### Mejorado
+
+- **Rate limiting adaptativo:** delay inicial 0ms (sin penalización previa), se activa solo tras HTTP 429, incremento exponencial suave ×1.6 (0ms → 25ms → 40ms → 64ms → 102ms). Resultado: ~7 conv/s (~0.15s por convocatoria).
+
+- **Consulta optimizada en `scrape_diario`:** cambio de `MAX(fecha_recepcion)` (escaneo completo) a `ORDER BY id DESC LIMIT 1` (usa índice PK). Mejora de 250x (500ms → 2ms). Los IDs más altos corresponden implícitamente a fechas más recientes.
+
+- **`scrape_diario`:** ahora también obtiene detalles completos de cada convocatoria nueva (antes solo guardaba datos ligeros). Validación mejorada: lanza error descriptivo si la tabla está vacía, indicando ejecutar ingest histórico primero.
+
+- **`scrape_historico`:** generación de múltiples parquets por batches (max 100 registros cada uno) en lugar de un solo parquet grande. Nomenclatura: `_part_subvenciones_000.parquet`, `_part_subvenciones_001.parquet`, etc.
+
+- **`etl/ingest_l0.py`:** actualizado `SUBVENCIONES_PARQUET_COLUMNS` con las 32 columnas del nuevo schema.
+
+### Eliminado
+
+- **`nacional/subvenciones.py`:**
+  - Endpoint `/ultimas` (ahora todo usa `/busqueda` con parámetro `direccion`).
+  - Clase `LatestParams` (sustituida por `SearchParams` con campo `direccion`).
+  - Clase `RateLimiter` (sustituida por rate limiting global adaptativo).
+  - Constante `API_ENDPOINT_ULTIMAS`.
+  - Campos redundantes: `numero_convocatoria`, `codigo_bdns` (redundantes con `id`), `codigo_invente` (no disponible en API).
+
+### Corregido
+
+- **Bug crítico en `scrape_historico`:** función `fetcher()` usaba variable `numero_conv` indefinida, causando que todas las peticiones usaran el mismo ID. Solo el primer registro se insertaba, los 607 restantes se marcaban como duplicados. Corregido a `conv["id"]`. Tasa de éxito: 0.16% → 100%.
+
+### Migración requerida (BREAKING CHANGE)
+
+**ATENCIÓN:** Estructura de tabla incompatible (6 → 32 campos). Datos existentes no son compatibles.
+
+1. Borrar datos antiguos:
+
+   ```sql
+   TRUNCATE TABLE l0.nacional_subvenciones;
+   ```
+
+2. Aplicar nuevo schema:
+
+   ```bash
+   docker compose exec etl licitia-etl init-db
+   ```
+
+3. Reingestar datos:
+   ```bash
+   docker compose exec etl licitia-etl ingest nacional subvenciones --anos 2020-2026
+   ```
+
+**Nota:** El proceso de migración puede tardar varias horas dependiendo de los años a ingestar.
+
+---
+
 ## [1.5.1] — 2026-04-17
 
 ### Resumen
@@ -212,12 +291,14 @@ La integración completa con `upstream/main` quedó resuelta en **[1.3.2]**.
 ## [1.1.2] — 2026-03-25
 
 ### Upstream sync (BquantFinance/licitaciones-espana)
+
 - **Andalucía scraper refactor** (`scripts/ccaa_andalucia.py`): improved coverage and stability (upstream PR #5); 11 new tests in `tests/test_ccaa_andalucia.py`
 - **Asturias downloader script** (`scripts/ccaa_asturias.py`): new standalone script to fetch contracts from Asturias open-data portal to Parquet; see `scripts/README.md` for usage. Ingest wiring (CONJUNTOS_REGISTRY) deferred to 1.2.0.
 - **Calidad analytics module** (`calidad/calidad_licitaciones.py`): 20 quality indicators on contracts dataset; standalone tool, not part of ingest pipeline
 - `requirements.txt`: `requests>=2.31.0` added; `numpy<2` pin preserved
 
 ### Fork changes
+
 - **Data hygiene**: removed `catalunya/README.md` (doc-only); `.gitignore` updated to cover `asturias_data/`, `ccaa_Andalucia/perfiles_cache.json`, `catalunya/`
 - **No new HTTP API routes** added in this release; API surface unchanged from 1.1.1
 - **No new CLI subcommands** added; ingest catalog visible via `GET /ingest/conjuntos` (8 conjuntos)
@@ -225,25 +306,27 @@ La integración completa con `upstream/main` quedó resuelta en **[1.3.2]**.
 ### QA performed (2026-03-25)
 
 **CLI / pytest**
+
 - 55 tests passed, 1 skipped (DB-dependent), 0 failed — full suite including 11 new upstream Andalucía tests
 - `python -m etl.cli --help` and `python -m etl.cli ingest --help` — exit 0, no import errors
 - `calidad.calidad_licitaciones` imports cleanly
 
 **API (ETL microservice at `http://localhost:8002`)**
 
-| Endpoint | HTTP | Notes |
-|----------|------|-------|
-| `GET /health` | 200 | `db: true`, 4 migrations pending |
-| `GET /status` | 200 | `database: connected` |
-| `GET /db-info` | 200 | 37 tables, 765 MB |
-| `GET /ingest/conjuntos` | 200 | 8 conjuntos returned |
-| `GET /migrations` | 200 | 6 applied, 4 pending |
-| `GET /scheduler/status` | 200 | 5 nacional tasks registered, `loop_running: false` |
-| `GET /scheduler/running` | 200 | No active runs |
+| Endpoint                 | HTTP | Notes                                              |
+| ------------------------ | ---- | -------------------------------------------------- |
+| `GET /health`            | 200  | `db: true`, 4 migrations pending                   |
+| `GET /status`            | 200  | `database: connected`                              |
+| `GET /db-info`           | 200  | 37 tables, 765 MB                                  |
+| `GET /ingest/conjuntos`  | 200  | 8 conjuntos returned                               |
+| `GET /migrations`        | 200  | 6 applied, 4 pending                               |
+| `GET /scheduler/status`  | 200  | 5 nacional tasks registered, `loop_running: false` |
+| `GET /scheduler/running` | 200  | No active runs                                     |
 
 No 500 errors. All endpoints returned expected codes.
 
 ### Notes
+
 - API version string updated from 1.1.0 → 1.1.2
 - 4 schema migrations on disk pending application (`005_catalunya.sql`, `006_valencia.sql`, `007_views.sql`, `010_borme.sql`) — apply via `POST /init-db` or `licitia-etl init-db`
 - `etl/__init__.py` `__version__` remains `1.1.0`; full multi-file semver alignment planned for 1.2.0
@@ -280,8 +363,6 @@ No 500 errors. All endpoints returned expected codes.
 
 - **get_tasks_due:** Uso de `reference_now` en `get_next_run_at` para que las tareas nunca ejecutadas se consideren debidas en el mismo tick (evita desfase de milisegundos que dejaba `due_count` en 0).
 - **insert_run_start:** Firma correcta `insert_run_start(conn, task_id)` en `cmd_ingest`.
-
-
 
 ### Nota
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Todos los cambios notables del CLI y del microservicio ETL se documentan aquí.
 
-## [1.5.2] — 2026-04-21
+## [1.5.2] — 2026-04-23
 
 ### Resumen
 
@@ -12,6 +12,9 @@ Todos los cambios notables del CLI y del microservicio ETL se documentan aquí.
 - **Nueva arquitectura de scraping en 2 fases:** fase 1 obtiene IDs ligeros (`/busqueda`), fase 2 obtiene detalles completos por cada ID (`/convocatorias`).
 - **Optimizaciones de rendimiento:** rate limiting adaptativo global thread-safe, multithreading producer-consumer para scraping histórico, carga paralela de parquets, consulta optimizada 250x más rápida.
 - **Eliminación de dependencia API externa:** con datos completos en BD, Licitia ya no necesita llamar a API externa para obtener detalles de subvenciones.
+- **Limpieza de campos:** eliminados `text_inicio` y `text_fin` (backups de fecha en texto plano) para reducir ruido en BD.
+- **Filtrado de caducadas en preprocesamiento:** el thread `saver` descarta convocatorias con `abierto = False` y `fecha_fin_solicitud` pasada antes de guardarlas.
+- **Nuevo campo `resumen_bases_reguladoras TEXT`:** reservado para feature futura, siempre `NULL` en ingesta.
 
 ### Añadido
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Todos los cambios notables del CLI y del microservicio ETL se documentan aquí.
 ### Resumen
 
 - **Ingesta completa de datos de subvenciones:** migración de 6 a 32 campos por convocatoria, guardando TODOS los datos detallados (instrumentos, beneficiarios, sectores, regiones, presupuesto, documentos, anuncios) en lugar de solo datos ligeros.
+- **Normalización de schema:** campos JSONB convertidos a estructuras tipadas (FKs, arrays PostgreSQL nativos) para mejorar rendimiento de consultas e integridad referencial.
+- **Simplificación de campos:** extracción de valores únicos (primer instrumento, primer objetivo, solo descripción) para reducir complejidad y redundancia.
 - **Nueva arquitectura de scraping en 2 fases:** fase 1 obtiene IDs ligeros (`/busqueda`), fase 2 obtiene detalles completos por cada ID (`/convocatorias`).
 - **Optimizaciones de rendimiento:** rate limiting adaptativo global thread-safe, multithreading producer-consumer para scraping histórico, carga paralela de parquets, consulta optimizada 250x más rápida.
 - **Eliminación de dependencia API externa:** con datos completos en BD, Licitia ya no necesita llamar a API externa para obtener detalles de subvenciones.
@@ -15,6 +17,14 @@ Todos los cambios notables del CLI y del microservicio ETL se documentan aquí.
 
 - **`nacional/subvenciones.py`:**
   - Nueva función `fetch_convocatoria_detalle()`: obtiene información completa de una convocatoria desde endpoint de detalle con rate limiting adaptativo.
+  - Funciones de normalización con cachés en memoria:
+    - `_load_instrumentos_map()` y `_extract_instrumento_id()`: mapeo de descripciones JSONB a IDs de `dim.instrumentos_subvenciones`, extrae solo el primer instrumento.
+    - `_load_beneficiarios_map()` y `_extract_beneficiarios_ids()`: mapeo de descripciones JSONB a array de IDs de `dim.beneficiarios_subvenciones`.
+    - `_extract_nut_codes()`: extracción de códigos NUT (regiones) desde API.
+    - `_extract_sector_codes()`: extracción de códigos CNAE (sectores) con normalización de decimales (`'96.4'` → `'9640'`).
+    - `_extract_reglamento_descripcion()`: extrae solo campo `descripcion`, descarta campo `orden`.
+    - `_extract_objetivos_descripcion()`: extrae solo descripción del primer objetivo, descarta objetivos adicionales.
+    - `_normalize_empty_jsonb()`: convierte arrays vacíos `[]` a `None`.
   - Funciones helper `_flatten_organo()` y `_convert_to_json_serializable()` para procesamiento de datos.
   - Rate limiting adaptativo global con `_api_delay_seconds` y `_api_delay_lock` (thread-safe).
   - Pattern producer-consumer en `scrape_historico`: thread fetcher obtiene detalles y pone en Queue, thread saver consume Queue y genera parquets por batches.
@@ -25,8 +35,16 @@ Todos los cambios notables del CLI y del microservicio ETL se documentan aquí.
   - Solo activo para `nacional/subvenciones` con múltiples archivos parquet.
 
 - **`schemas/012_nacional_subvenciones.sql`:**
-  - 26 campos nuevos: `sede_electronica`, `tipo_convocatoria`, `presupuesto_total`.
-  - 10 arrays JSONB: `instrumentos`, `tipos_beneficiarios`, `sectores`, `regiones`, `fondos`, `reglamento`, `objetivos`, `sectores_productos`, `documentos`, `anuncios`.
+  - Campos normalizados con estructuras tipadas:
+    - `instrumento_id SMALLINT`: FK a `dim.instrumentos_subvenciones(id)`, extrae solo el primer instrumento del array JSONB.
+    - `tipos_beneficiarios SMALLINT[]`: array de FKs a `dim.beneficiarios_subvenciones(id)`, mapeo de descripciones a IDs.
+    - `sectores VARCHAR(10)[]`: array de códigos CNAE/NACE con normalización de decimales, referencia a `dim.cnae_dim(codigo)`.
+    - `regiones VARCHAR(10)[]`: array de códigos NUT, FK a `dim.nuts_spain(geocode)`.
+    - `reglamento TEXT`: solo campo `descripcion`, descartado campo `orden`.
+    - `objetivos TEXT`: solo descripción del primer objetivo, descartados objetivos adicionales.
+  - Campos JSONB optimizados: arrays vacíos `[]` convertidos a `NULL` en `fondos`, `sectores_productos`, `documentos`, `anuncios`.
+  - Índices GIN en arrays para búsquedas eficientes con operadores `@>`, `&&`, `ANY()`.
+  - 26 campos adicionales: `sede_electronica`, `tipo_convocatoria`, `presupuesto_total`.
   - Campos de bases reguladoras: `descripcion_finalidad`, `descripcion_bases_reguladoras`, `url_bases_reguladoras`.
   - Estado y fechas: `abierto`, `se_publica_diario_oficial`, `fecha_inicio_solicitud`, `fecha_fin_solicitud`, `text_inicio`, `text_fin`.
   - Ayuda de estado: `ayuda_estado`, `url_ayuda_estado`.
@@ -41,7 +59,7 @@ Todos los cambios notables del CLI y del microservicio ETL se documentan aquí.
 
 - **`scrape_historico`:** generación de múltiples parquets por batches (max 100 registros cada uno) en lugar de un solo parquet grande. Nomenclatura: `_part_subvenciones_000.parquet`, `_part_subvenciones_001.parquet`, etc.
 
-- **`etl/ingest_l0.py`:** actualizado `SUBVENCIONES_PARQUET_COLUMNS` con las 32 columnas del nuevo schema.
+- **`etl/ingest_l0.py`:** actualizado `SUBVENCIONES_PARQUET_COLUMNS` con tipos normalizados (SMALLINT, SMALLINT[], VARCHAR[], TEXT). Lógica de inserción mejorada para manejar arrays PostgreSQL nativos (conversión automática de numpy arrays a listas Python, deserialización de JSON cuando necesario).
 
 ### Eliminado
 
@@ -58,7 +76,15 @@ Todos los cambios notables del CLI y del microservicio ETL se documentan aquí.
 
 ### Migración requerida (BREAKING CHANGE)
 
-**ATENCIÓN:** Estructura de tabla incompatible (6 → 32 campos). Datos existentes no son compatibles.
+**ATENCIÓN:** Estructura de tabla incompatible (6 → 32 campos, JSONB → estructuras tipadas). Datos existentes no son compatibles.
+
+**Simplificaciones aplicadas:**
+
+- Solo se guarda el **primer instrumento** del array (campo `instrumento_id`).
+- Solo se guarda la **descripción del primer objetivo** (campo `objetivos TEXT`).
+- Campo `reglamento`: solo se guarda `descripcion`, se descarta `orden`.
+- Códigos CNAE con decimales se normalizan automáticamente (`'96.4'` → `'9640'`).
+- Arrays vacíos `[]` se convierten a `NULL`.
 
 1. Borrar datos antiguos:
 
@@ -77,7 +103,7 @@ Todos los cambios notables del CLI y del microservicio ETL se documentan aquí.
    docker compose exec etl licitia-etl ingest nacional subvenciones --anos 2020-2026
    ```
 
-**Nota:** El proceso de migración puede tardar varias horas dependiendo de los años a ingestar.
+**Nota:** El proceso de migración puede tardar varias horas dependiendo de los años a ingestar. Ver `ignored/CAMBIOS_SCHEMA_SUBVENCIONES.md` para guía completa de migración.
 
 ---
 

--- a/etl/cli.py
+++ b/etl/cli.py
@@ -11,6 +11,8 @@ import signal
 import subprocess
 import sys
 import time
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Optional
 
@@ -107,22 +109,16 @@ def cmd_status(_args: argparse.Namespace) -> int:
     return 0
 
 
-def run_init_db(
-    url: str | None = None, schema_dir: Path | None = None
-) -> tuple[int, list[dict]]:
+def run_init_db(url: str | None = None, schema_dir: Path | None = None) -> tuple[int, list[dict]]:
     """Run init-db logic: create schemas, apply INIT_MIGRATIONS, run DIR3 hook. Returns (exit_code, results)."""
     from etl import schema_check
 
     url = url or get_database_url()
     if not url:
-        return 1, [
-            {"filename": "", "success": False, "error": "Database not configured"}
-        ]
+        return 1, [{"filename": "", "success": False, "error": "Database not configured"}]
     db_schema = get_db_schema()
     if not db_schema or not db_schema.replace("_", "").isalnum():
-        return 1, [
-            {"filename": "", "success": False, "error": "DB_SCHEMA not set or invalid"}
-        ]
+        return 1, [{"filename": "", "success": False, "error": "DB_SCHEMA not set or invalid"}]
     schema_dir = schema_dir or _schema_dir()
     if not schema_dir.exists():
         return 1, [
@@ -133,9 +129,7 @@ def run_init_db(
             }
         ]
 
-    etl_schemas_sql = (
-        f"CREATE SCHEMA IF NOT EXISTS dim; CREATE SCHEMA IF NOT EXISTS {db_schema};"
-    )
+    etl_schemas_sql = f"CREATE SCHEMA IF NOT EXISTS dim; CREATE SCHEMA IF NOT EXISTS {db_schema};"
     try:
         with psycopg2.connect(url) as conn:
             conn.autocommit = False
@@ -182,23 +176,15 @@ def run_init_db(
                 pgcode = getattr(e, "pgcode", None)
                 msg = str(e).lower()
                 skip_codes = ("42P07", "23505")
-                if (
-                    pgcode in skip_codes
-                    or "already exists" in msg
-                    or "duplicate key" in msg
-                ):
+                if pgcode in skip_codes or "already exists" in msg or "duplicate key" in msg:
                     schema_check.record(conn, filename, checksum)
                     results.append({"filename": filename, "success": True})
                     continue
                 try:
-                    schema_check.record(
-                        conn, filename, checksum, success=False, error_msg=str(e)
-                    )
+                    schema_check.record(conn, filename, checksum, success=False, error_msg=str(e))
                 except Exception:
                     pass
-                results.append(
-                    {"filename": filename, "success": False, "error": str(e)}
-                )
+                results.append({"filename": filename, "success": False, "error": str(e)})
                 conn.close()
                 return 1, results
 
@@ -252,9 +238,7 @@ def cmd_init_db(args: argparse.Namespace) -> int:
         return 1
 
     url = get_database_url()
-    etl_schemas_sql = (
-        f"CREATE SCHEMA IF NOT EXISTS dim; CREATE SCHEMA IF NOT EXISTS {db_schema};"
-    )
+    etl_schemas_sql = f"CREATE SCHEMA IF NOT EXISTS dim; CREATE SCHEMA IF NOT EXISTS {db_schema};"
     try:
         with psycopg2.connect(url) as conn:
             conn.autocommit = False
@@ -317,9 +301,7 @@ def _parse_anos(anos_str: str) -> tuple[int, int]:
 
 def cmd_ingest_test(args: argparse.Namespace) -> int:
     """Ejecuta la suite de tests de ingest (pytest), E2E por conjuntos, o limpieza del schema test."""
-    if getattr(args, "ingest_delete", False) and not getattr(
-        args, "ingest_conjuntos", False
-    ):
+    if getattr(args, "ingest_delete", False) and not getattr(args, "ingest_conjuntos", False):
         return _drop_e2e_schema()
     if getattr(args, "ingest_conjuntos", False):
         return _cmd_ingest_test_conjuntos_e2e(args)
@@ -420,9 +402,7 @@ def _cmd_ingest_test_conjuntos_e2e(args: argparse.Namespace) -> int:
             return rc
     if getattr(args, "ingest_delete", False):
         _drop_e2e_schema()
-    print(
-        "E2E completado: un subconjunto de cada conjunto verificado.", file=sys.stderr
-    )
+    print("E2E completado: un subconjunto de cada conjunto verificado.", file=sys.stderr)
     return 0
 
 
@@ -617,9 +597,7 @@ def cmd_ingest(args: argparse.Namespace) -> int:
                     ingest_result[0] = "ok"
                     return 0
             elif "scripts" in reg:
-                run_cwd = (
-                    etl_root / reg["script_cwd"] if reg.get("script_cwd") else etl_root
-                )
+                run_cwd = etl_root / reg["script_cwd"] if reg.get("script_cwd") else etl_root
                 if conjunto == "ted":
                     # TED: un solo script con download y --years
                     if ano_inicio is None or ano_fin is None:
@@ -662,24 +640,13 @@ def cmd_ingest(args: argparse.Namespace) -> int:
                             "ccaa_andalucia.py"
                         ):
                             cmd.append(reg["script_subconjunto_arg"][subconjunto])
-                        elif (
-                            conjunto == "andalucia"
-                            and "ccaa_andalucia_parquet.py" in script_rel
-                        ):
+                        elif conjunto == "andalucia" and "ccaa_andalucia_parquet.py" in script_rel:
                             cmd.extend(["--subconjunto", subconjunto])
-                        elif (
-                            conjunto == "valencia" and "ccaa_valencia.py" in script_rel
-                        ):
+                        elif conjunto == "valencia" and "ccaa_valencia.py" in script_rel:
                             cmd.extend(["--categories", subconjunto])
-                        elif (
-                            conjunto == "valencia"
-                            and "ccaa_valencia_parquet.py" in script_rel
-                        ):
+                        elif conjunto == "valencia" and "ccaa_valencia_parquet.py" in script_rel:
                             cmd.extend(["--categories", subconjunto])
-                        elif (
-                            conjunto == "catalunya"
-                            and "ccaa_cataluna_parquet.py" in script_rel
-                        ):
+                        elif conjunto == "catalunya" and "ccaa_cataluna_parquet.py" in script_rel:
                             parquet_rel = CATALUNYA_PARQUET_PATHS[subconjunto]
                             cmd.extend(["--parquet-rel", parquet_rel])
                         elif (
@@ -692,9 +659,7 @@ def cmd_ingest(args: argparse.Namespace) -> int:
                                 cmd.extend(["--limit-datasets", ids])
                         print(f"Ejecutando: {' '.join(cmd)}", file=sys.stderr)
                         try:
-                            rc = subprocess.run(
-                                cmd, cwd=run_cwd, env=run_env, check=False
-                            )
+                            rc = subprocess.run(cmd, cwd=run_cwd, env=run_env, check=False)
                             if rc.returncode != 0:
                                 print(
                                     "[ingest] Error en fase descarga/generación; considerar reintentar.",
@@ -717,9 +682,7 @@ def cmd_ingest(args: argparse.Namespace) -> int:
                     return 0
             else:
                 if solo_descargar:
-                    print(
-                        "No hay script configurado para este conjunto.", file=sys.stderr
-                    )
+                    print("No hay script configurado para este conjunto.", file=sys.stderr)
                     return 1
             if "script_module" in reg:
                 print(f"Ejecutando: {' '.join(cmd)}", file=sys.stderr)
@@ -797,57 +760,134 @@ def cmd_ingest(args: argparse.Namespace) -> int:
         total_skipped = 0
         batch_errors: list[str] = []
 
-        for batch_idx, pq in enumerate(parquet_files, start=1):
-            label = f"[{batch_idx}/{len(parquet_files)}]"
-            print(f"[ingest] {label} Cargando {pq.name}...", file=sys.stderr)
+        use_threadpool = (
+            conjunto == "nacional" and subconjunto == "subvenciones" and len(parquet_files) > 1
+        )
+        max_workers = 3 if use_threadpool else 1
 
-            if column_defs is None and pq.exists():
-                column_defs = infer_column_defs_from_parquet(pq)
+        if use_threadpool:
+            print(
+                f"[ingest] Usando ThreadPool con {max_workers} workers para carga paralela.",
+                file=sys.stderr,
+            )
+            stats_lock = threading.Lock()
 
-            try:
-                inserted, skipped = load_parquet_to_l0(
-                    get_database_url(),
-                    db_schema,
-                    table_name,
-                    pq,
-                    get_ingest_batch_size(),
-                    column_defs=column_defs,
-                    natural_id_col=natural_id_col,
-                )
-                total_inserted += inserted
-                total_skipped += skipped
-                print(
-                    f"[ingest] {label} +{inserted} insertadas, {skipped} omitidas (acum: {total_inserted}+{total_skipped}).",
-                    file=sys.stderr,
-                )
+            def load_parquet_worker(batch_idx: int, pq: Path):
+                """Worker function to load a single parquet file."""
+                label = f"[{batch_idx}/{len(parquet_files)}]"
+                print(f"[ingest] {label} Cargando {pq.name}...", file=sys.stderr)
 
-                if run_id and db_url:
-                    try:
-                        from etl.scheduler import update_run_progress
+                try:
+                    inserted, skipped = load_parquet_to_l0(
+                        get_database_url(),
+                        db_schema,
+                        table_name,
+                        pq,
+                        get_ingest_batch_size(),
+                        column_defs=column_defs,
+                        natural_id_col=natural_id_col,
+                    )
 
-                        with psycopg2.connect(db_url) as _conn:
-                            update_run_progress(
-                                _conn,
-                                run_id,
-                                total_inserted,
-                                total_skipped,
-                                f"Batch {batch_idx}/{len(parquet_files)}",
-                            )
-                            _conn.commit()
-                    except Exception:
-                        pass
+                    with stats_lock:
+                        nonlocal total_inserted, total_skipped
+                        total_inserted += inserted
+                        total_skipped += skipped
+                        print(
+                            f"[ingest] {label} +{inserted} insertadas, {skipped} omitidas (acum: {total_inserted}+{total_skipped}).",
+                            file=sys.stderr,
+                        )
 
-                if use_partials:
-                    try:
-                        pq.unlink(missing_ok=True)
-                    except OSError:
-                        pass
+                    if run_id and db_url:
+                        try:
+                            from etl.scheduler import update_run_progress
 
-            except Exception as e:
-                msg = f"Error en batch {batch_idx}: {e}"
-                print(f"[ingest] {msg}", file=sys.stderr)
-                batch_errors.append(msg)
-                continue
+                            with psycopg2.connect(db_url) as _conn:
+                                update_run_progress(
+                                    _conn,
+                                    run_id,
+                                    total_inserted,
+                                    total_skipped,
+                                    f"Batch {batch_idx}/{len(parquet_files)}",
+                                )
+                                _conn.commit()
+                        except Exception:
+                            pass
+
+                    if use_partials:
+                        try:
+                            pq.unlink(missing_ok=True)
+                        except OSError:
+                            pass
+
+                    return None
+
+                except Exception as e:
+                    msg = f"Error en batch {batch_idx}: {e}"
+                    print(f"[ingest] {msg}", file=sys.stderr)
+                    return msg
+
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = {
+                    executor.submit(load_parquet_worker, idx, pq): idx
+                    for idx, pq in enumerate(parquet_files, start=1)
+                }
+
+                for future in as_completed(futures):
+                    error = future.result()
+                    if error:
+                        batch_errors.append(error)
+        else:
+            for batch_idx, pq in enumerate(parquet_files, start=1):
+                label = f"[{batch_idx}/{len(parquet_files)}]"
+                print(f"[ingest] {label} Cargando {pq.name}...", file=sys.stderr)
+
+                if column_defs is None and pq.exists():
+                    column_defs = infer_column_defs_from_parquet(pq)
+
+                try:
+                    inserted, skipped = load_parquet_to_l0(
+                        get_database_url(),
+                        db_schema,
+                        table_name,
+                        pq,
+                        get_ingest_batch_size(),
+                        column_defs=column_defs,
+                        natural_id_col=natural_id_col,
+                    )
+                    total_inserted += inserted
+                    total_skipped += skipped
+                    print(
+                        f"[ingest] {label} +{inserted} insertadas, {skipped} omitidas (acum: {total_inserted}+{total_skipped}).",
+                        file=sys.stderr,
+                    )
+
+                    if run_id and db_url:
+                        try:
+                            from etl.scheduler import update_run_progress
+
+                            with psycopg2.connect(db_url) as _conn:
+                                update_run_progress(
+                                    _conn,
+                                    run_id,
+                                    total_inserted,
+                                    total_skipped,
+                                    f"Batch {batch_idx}/{len(parquet_files)}",
+                                )
+                                _conn.commit()
+                        except Exception:
+                            pass
+
+                    if use_partials:
+                        try:
+                            pq.unlink(missing_ok=True)
+                        except OSError:
+                            pass
+
+                except Exception as e:
+                    msg = f"Error en batch {batch_idx}: {e}"
+                    print(f"[ingest] {msg}", file=sys.stderr)
+                    batch_errors.append(msg)
+                    continue
 
         if batch_errors and total_inserted == 0:
             ingest_result[0] = "failed"
@@ -1050,11 +1090,7 @@ def cmd_scheduler_status(_args: argparse.Namespace) -> int:
             pid_str = str(pid_val) if pid_val is not None else "-"
             pid_str = pid_str[:8]
             ins, omit = r.get("last_rows_inserted"), r.get("last_rows_omitted")
-            filas = (
-                f"{ins or 0}+{omit or 0}"
-                if (ins is not None or omit is not None)
-                else "-"
-            )
+            filas = f"{ins or 0}+{omit or 0}" if (ins is not None or omit is not None) else "-"
             if raw_status == "running":
                 next_run = "-"
             else:
@@ -1139,9 +1175,7 @@ def cmd_scheduler_run(args: argparse.Namespace) -> int:
         try:
             p = subprocess.Popen(cmd, **kwargs)
         except Exception as e:
-            print(
-                f"Error al arrancar el scheduler en segundo plano: {e}", file=sys.stderr
-            )
+            print(f"Error al arrancar el scheduler en segundo plano: {e}", file=sys.stderr)
             return 1
         time.sleep(1)
         print(f"Scheduler iniciado en segundo plano. PID: {p.pid}. Log: {log_path}")
@@ -1264,14 +1298,10 @@ def cmd_scheduler_unregister(args: argparse.Namespace) -> int:
                 pass
             except OSError:
                 pass
-            update_run_finish(
-                conn, run_id, "failed", error_message="Detenido por unregister"
-            )
+            update_run_finish(conn, run_id, "failed", error_message="Detenido por unregister")
             delete_task(conn, task_id)
             conn.commit()
-            print(
-                f"Tarea {conjunto} / {subconjunto} (task_id={task_id}) eliminada del scheduler."
-            )
+            print(f"Tarea {conjunto} / {subconjunto} (task_id={task_id}) eliminada del scheduler.")
             return 0
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -1290,9 +1320,7 @@ def cmd_db_info(_args: argparse.Namespace) -> int:
     try:
         with psycopg2.connect(url) as conn:
             with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT pg_size_pretty(pg_database_size(current_database()))"
-                )
+                cur.execute("SELECT pg_size_pretty(pg_database_size(current_database()))")
                 db_total = cur.fetchone()
                 print(f"Base de datos: {db_total[0] if db_total else '?'}\n")
                 print("Tamaño por schema:")
@@ -1566,9 +1594,7 @@ def cmd_borme(args: argparse.Namespace) -> int:
     elif borme_cmd == "anomalias":
         pdfs_dir = run_scraper(args.anos)
         parsed_dir = run_parser(pdfs_dir)
-        output = run_anomalias(
-            parsed_dir, anonimizar=getattr(args, "anonimizar", False)
-        )
+        output = run_anomalias(parsed_dir, anonimizar=getattr(args, "anonimizar", False))
         print(f"BORME anomalías completadas. Resultados en: {output}")
         return 0
     else:
@@ -1683,8 +1709,7 @@ def main() -> int:
     )
     group_ingest = ingest_parser.add_argument_group(
         "Opciones para ingest real",
-        "Solo tienen efecto cuando conjunto es uno de: %s."
-        % ", ".join(sorted(CONJUNTOS_REGISTRY)),
+        "Solo tienen efecto cuando conjunto es uno de: %s." % ", ".join(sorted(CONJUNTOS_REGISTRY)),
     )
     group_ingest.add_argument(
         "--subconjuntos",
@@ -1727,9 +1752,7 @@ def main() -> int:
         "scheduler",
         help="Gestiona las tareas programadas de ingest (registro, estado, ejecución y parada).",
     )
-    sched_sub = sched_parser.add_subparsers(
-        dest="scheduler_cmd", help="Subcomando", required=True
-    )
+    sched_sub = sched_parser.add_subparsers(dest="scheduler_cmd", help="Subcomando", required=True)
     _sched_registry_list = (
         ", ".join(
             f"{c} ({len(r['subconjuntos'])})"
@@ -1841,19 +1864,11 @@ def main() -> int:
     )
     borme_sub = borme_parser.add_subparsers(dest="borme_cmd", help="Subcomando BORME")
 
-    borme_ingest = borme_sub.add_parser(
-        "ingest", help="Scrape + parse + load into borme schema"
-    )
-    borme_ingest.add_argument(
-        "--anos", required=True, help="Year range: 2020-2026 or 2024"
-    )
+    borme_ingest = borme_sub.add_parser("ingest", help="Scrape + parse + load into borme schema")
+    borme_ingest.add_argument("--anos", required=True, help="Year range: 2020-2026 or 2024")
 
-    borme_anomalias = borme_sub.add_parser(
-        "anomalias", help="Run anomaly detector vs L0 nacional"
-    )
-    borme_anomalias.add_argument(
-        "--anos", required=True, help="Year range: 2020-2026 or 2024"
-    )
+    borme_anomalias = borme_sub.add_parser("anomalias", help="Run anomaly detector vs L0 nacional")
+    borme_anomalias.add_argument("--anos", required=True, help="Year range: 2020-2026 or 2024")
     borme_anomalias.add_argument(
         "--anonimizar", action="store_true", help="Anonymize before matching"
     )
@@ -1866,13 +1881,9 @@ def main() -> int:
         help="Actualización diaria de subvenciones desde API.",
         description="Actualización diaria de subvenciones: scrape de últimas convocatorias e insert directo en BD.",
     )
-    subv_sub = subv_parser.add_subparsers(
-        dest="subvenciones_cmd", help="Subcomando subvenciones"
-    )
+    subv_sub = subv_parser.add_subparsers(dest="subvenciones_cmd", help="Subcomando subvenciones")
 
-    subv_diario = subv_sub.add_parser(
-        "diario", help="Actualización diaria (últimas subvenciones)"
-    )
+    subv_diario = subv_sub.add_parser("diario", help="Actualización diaria (últimas subvenciones)")
     subv_parser.set_defaults(func=cmd_subvenciones)
 
     cnae_parser = subparsers.add_parser(
@@ -1881,9 +1892,7 @@ def main() -> int:
         description="CNAE: ingesta de la clasificación nacional de actividades económicas desde la API ISTAC.",
     )
     cnae_sub = cnae_parser.add_subparsers(dest="cnae_cmd", help="Subcomando CNAE")
-    cnae_sub.add_parser(
-        "ingest", help="Fetch CNAE codes from ISTAC API and load into dim.cnae_dim"
-    )
+    cnae_sub.add_parser("ingest", help="Fetch CNAE codes from ISTAC API and load into dim.cnae_dim")
     cnae_parser.set_defaults(func=cmd_cnae)
 
     args = parser.parse_args()

--- a/etl/cli.py
+++ b/etl/cli.py
@@ -1471,9 +1471,9 @@ def cmd_subvenciones(args: argparse.Namespace) -> int:
 
         try:
             sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-            from nacional.subvenciones import scrape_diario, LatestParams
+            from nacional.subvenciones import scrape_diario, SearchParams
 
-            params = LatestParams(page=0, pageSize=100)
+            params = SearchParams(page=0, pageSize=100)
             result = scrape_diario(params)
             subv_result[0] = "ok"
             subv_result[1] = result.get("inserted", 0)

--- a/etl/ingest_l0.py
+++ b/etl/ingest_l0.py
@@ -4,6 +4,7 @@ PK surrogada: l0_id BIGSERIAL PRIMARY KEY + natural_id TEXT UNIQUE NOT NULL (URL
 Deriva prefijos CPV (principal_prefix4/6, secondary_prefix6), asegura tablas con índices e inserta con ON CONFLICT (natural_id) DO NOTHING.
 """
 
+import json
 import logging
 import os
 import re
@@ -808,8 +809,17 @@ def load_parquet_to_l0(
 
                             # Handle arrays (SMALLINT[], VARCHAR[], etc.)
                             if "[]" in pg_type:
+                                # Parse if it's a JSON string (from serialization)
+                                if isinstance(v, str):
+                                    try:
+                                        v = json.loads(v)
+                                    except (json.JSONDecodeError, TypeError):
+                                        pass
+
                                 # Convert numpy arrays to Python lists
                                 converted = _convert_numpy_to_python(v)
+
+                                # Handle None or empty arrays
                                 if converted is None or (
                                     isinstance(converted, list) and len(converted) == 0
                                 ):

--- a/etl/ingest_l0.py
+++ b/etl/ingest_l0.py
@@ -109,17 +109,17 @@ SUBVENCIONES_PARQUET_COLUMNS = [
     # Información básica
     ("sede_electronica", "TEXT"),
     ("fecha_recepcion", "DATE"),
-    # Instrumentos y tipo
-    ("instrumentos", "JSONB"),
+    # Instrumentos y tipo (normalizado)
+    ("instrumento_id", "SMALLINT"),
     ("tipo_convocatoria", "TEXT"),
     ("presupuesto_total", "NUMERIC"),
     ("mrr", "BOOLEAN"),
     ("descripcion", "TEXT"),
     ("descripcion_leng", "TEXT"),
-    # Beneficiarios y sectores
-    ("tipos_beneficiarios", "JSONB"),
-    ("sectores", "JSONB"),
-    ("regiones", "JSONB"),
+    # Beneficiarios y sectores (arrays normalizados)
+    ("tipos_beneficiarios", "SMALLINT[]"),
+    ("sectores", "VARCHAR(10)[]"),
+    ("regiones", "VARCHAR(10)[]"),
     # Finalidad y bases reguladoras
     ("descripcion_finalidad", "TEXT"),
     ("descripcion_bases_reguladoras", "TEXT"),
@@ -135,11 +135,11 @@ SUBVENCIONES_PARQUET_COLUMNS = [
     # Ayuda de estado
     ("ayuda_estado", "TEXT"),
     ("url_ayuda_estado", "TEXT"),
-    # Fondos y reglamento
+    # Fondos y reglamento (simplificado)
     ("fondos", "JSONB"),
-    ("reglamento", "JSONB"),
-    # Objetivos y sectores productos
-    ("objetivos", "JSONB"),
+    ("reglamento", "TEXT"),
+    # Objetivos y sectores productos (simplificado)
+    ("objetivos", "TEXT"),
     ("sectores_productos", "JSONB"),
     # Documentos y anuncios
     ("documentos", "JSONB"),
@@ -805,7 +805,18 @@ def load_parquet_to_l0(
                                 vals.append(None)
                                 continue
                             pg_type = next((t for col, t in column_defs if col == c), "TEXT")
-                            if "INT" in pg_type or "BIGINT" in pg_type:
+
+                            # Handle arrays (SMALLINT[], VARCHAR[], etc.)
+                            if "[]" in pg_type:
+                                # Convert to list if not already
+                                if isinstance(v, list):
+                                    vals.append(v if v else None)  # Empty list → None
+                                elif v is None:
+                                    vals.append(None)
+                                else:
+                                    # Single value → list with one element
+                                    vals.append([v])
+                            elif "INT" in pg_type or "BIGINT" in pg_type:
                                 try:
                                     vals.append(int(v))
                                 except (TypeError, ValueError):

--- a/etl/ingest_l0.py
+++ b/etl/ingest_l0.py
@@ -808,14 +808,17 @@ def load_parquet_to_l0(
 
                             # Handle arrays (SMALLINT[], VARCHAR[], etc.)
                             if "[]" in pg_type:
-                                # Convert to list if not already
-                                if isinstance(v, list):
-                                    vals.append(v if v else None)  # Empty list → None
-                                elif v is None:
-                                    vals.append(None)
+                                # Convert numpy arrays to Python lists
+                                converted = _convert_numpy_to_python(v)
+                                if converted is None or (
+                                    isinstance(converted, list) and len(converted) == 0
+                                ):
+                                    vals.append(None)  # Empty list → None
+                                elif isinstance(converted, list):
+                                    vals.append(converted)
                                 else:
                                     # Single value → list with one element
-                                    vals.append([v])
+                                    vals.append([converted])
                             elif "INT" in pg_type or "BIGINT" in pg_type:
                                 try:
                                     vals.append(int(v))

--- a/etl/ingest_l0.py
+++ b/etl/ingest_l0.py
@@ -101,16 +101,52 @@ NACIONAL_PARQUET_COLUMNS = [
 
 # Columnas del parquet de subvenciones
 SUBVENCIONES_PARQUET_COLUMNS = [
-    ("id", "INTEGER"),
-    ("numero_convocatoria", "TEXT"),
-    ("mrr", "BOOLEAN"),
-    ("descripcion", "TEXT"),
-    ("descripcion_leng", "TEXT"),
-    ("fecha_recepcion", "DATE"),
+    ("id", "BIGINT"),
+    # Órgano (aplanado)
     ("nivel1", "TEXT"),
     ("nivel2", "TEXT"),
     ("nivel3", "TEXT"),
-    ("codigo_invente", "TEXT"),
+    # Información básica
+    ("sede_electronica", "TEXT"),
+    ("codigo_bdns", "TEXT"),
+    ("fecha_recepcion", "DATE"),
+    # Instrumentos y tipo
+    ("instrumentos", "JSONB"),
+    ("tipo_convocatoria", "TEXT"),
+    ("presupuesto_total", "NUMERIC"),
+    ("mrr", "BOOLEAN"),
+    ("descripcion", "TEXT"),
+    ("descripcion_leng", "TEXT"),
+    # Beneficiarios y sectores
+    ("tipos_beneficiarios", "JSONB"),
+    ("sectores", "JSONB"),
+    ("regiones", "JSONB"),
+    # Finalidad y bases reguladoras
+    ("descripcion_finalidad", "TEXT"),
+    ("descripcion_bases_reguladoras", "TEXT"),
+    ("url_bases_reguladoras", "TEXT"),
+    # Publicación y estado
+    ("se_publica_diario_oficial", "BOOLEAN"),
+    ("abierto", "BOOLEAN"),
+    # Fechas de solicitud
+    ("fecha_inicio_solicitud", "DATE"),
+    ("fecha_fin_solicitud", "DATE"),
+    ("text_inicio", "TEXT"),
+    ("text_fin", "TEXT"),
+    # Ayuda de estado
+    ("ayuda_estado", "TEXT"),
+    ("url_ayuda_estado", "TEXT"),
+    # Fondos y reglamento
+    ("fondos", "JSONB"),
+    ("reglamento", "JSONB"),
+    # Objetivos y sectores productos
+    ("objetivos", "JSONB"),
+    ("sectores_productos", "JSONB"),
+    # Documentos y anuncios
+    ("documentos", "JSONB"),
+    ("anuncios", "JSONB"),
+    # Advertencia
+    ("advertencia", "TEXT"),
 ]
 
 # Nombre de la columna que en el parquet contiene el identificador único (URL); en la tabla L0 se persiste como natural_id.
@@ -464,7 +500,7 @@ def _convert_numpy_to_python(obj: Any) -> Any:
     if obj is None:
         return None
     # Arrays numpy: convertir a lista
-    if hasattr(obj, 'tolist'):
+    if hasattr(obj, "tolist"):
         return obj.tolist()
     # Listas: convertir cada elemento
     if isinstance(obj, list):

--- a/etl/ingest_l0.py
+++ b/etl/ingest_l0.py
@@ -122,7 +122,7 @@ SUBVENCIONES_PARQUET_COLUMNS = [
     ("sectores", "VARCHAR(10)[]"),
     ("regiones", "VARCHAR(10)[]"),
     # Finalidad y bases reguladoras
-    ("descripcion_finalidad", "TEXT"),
+    ("politica_gastos", "SMALLINT"),
     ("descripcion_bases_reguladoras", "TEXT"),
     ("url_bases_reguladoras", "TEXT"),
     ("resumen_bases_reguladoras", "TEXT"),

--- a/etl/ingest_l0.py
+++ b/etl/ingest_l0.py
@@ -108,7 +108,6 @@ SUBVENCIONES_PARQUET_COLUMNS = [
     ("nivel3", "TEXT"),
     # Información básica
     ("sede_electronica", "TEXT"),
-    ("codigo_bdns", "TEXT"),
     ("fecha_recepcion", "DATE"),
     # Instrumentos y tipo
     ("instrumentos", "JSONB"),

--- a/etl/ingest_l0.py
+++ b/etl/ingest_l0.py
@@ -125,6 +125,7 @@ SUBVENCIONES_PARQUET_COLUMNS = [
     ("descripcion_finalidad", "TEXT"),
     ("descripcion_bases_reguladoras", "TEXT"),
     ("url_bases_reguladoras", "TEXT"),
+    ("resumen_bases_reguladoras", "TEXT"),
     # Publicación y estado
     ("se_publica_diario_oficial", "BOOLEAN"),
     ("abierto", "BOOLEAN"),

--- a/etl/ingest_l0.py
+++ b/etl/ingest_l0.py
@@ -145,8 +145,6 @@ SUBVENCIONES_PARQUET_COLUMNS = [
     # Documentos y anuncios
     ("documentos", "JSONB"),
     ("anuncios", "JSONB"),
-    # Advertencia
-    ("advertencia", "TEXT"),
 ]
 
 # Nombre de la columna que en el parquet contiene el identificador único (URL); en la tabla L0 se persiste como natural_id.
@@ -580,11 +578,7 @@ def infer_column_defs_from_parquet(parquet_path: Path) -> list[tuple[str, str]]:
     except Exception as e:
         _configure_logging()
         err_msg = str(e).lower()
-        if (
-            "magic" in err_msg
-            or "arrowinvalid" in type(e).__name__.lower()
-            or "parquet" in err_msg
-        ):
+        if "magic" in err_msg or "arrowinvalid" in type(e).__name__.lower() or "parquet" in err_msg:
             logger.error(
                 "Parquet inválido (magic bytes no encontrados o fichero corrupto). "
                 "Comprobar que la ruta es un .parquet válido; si acabas de descargar, reintentar la descarga. %s",
@@ -652,9 +646,7 @@ def ensure_l0_table(
         col_defs.append('"ingested_at" TIMESTAMPTZ DEFAULT NOW()')
 
         create_sql = (
-            f"CREATE TABLE IF NOT EXISTS {full_table} (\n  "
-            + ",\n  ".join(col_defs)
-            + "\n)"
+            f"CREATE TABLE IF NOT EXISTS {full_table} (\n  " + ",\n  ".join(col_defs) + "\n)"
         )
         with conn.cursor() as cur:
             cur.execute(create_sql)
@@ -672,9 +664,7 @@ def ensure_l0_table(
                             f'CREATE INDEX IF NOT EXISTS {iname} ON {full_table} USING GIN ("{col}")'
                         )
                     else:
-                        cur.execute(
-                            f'CREATE INDEX IF NOT EXISTS {iname} ON {full_table} ("{col}")'
-                        )
+                        cur.execute(f'CREATE INDEX IF NOT EXISTS {iname} ON {full_table} ("{col}")')
 
             col_names = [c[0] for c in column_defs]
             if "expediente" in col_names and "id_plataforma" in col_names:
@@ -744,9 +734,7 @@ def load_parquet_to_l0(
                 len(df),
             )
         else:
-            logger.info(
-                "Filas con natural_id válido: %s de %s.", num_valid_nid, len(df)
-            )
+            logger.info("Filas con natural_id válido: %s de %s.", num_valid_nid, len(df))
 
     cpv_principal_col = "cpv_principal"
     cpvs_col = "cpvs"
@@ -780,9 +768,7 @@ def load_parquet_to_l0(
             ON CONFLICT (id) DO NOTHING
         """
     else:
-        table_base_cols = ["natural_id"] + [
-            c for c, _ in column_defs if c != natural_id_col
-        ]
+        table_base_cols = ["natural_id"] + [c for c, _ in column_defs if c != natural_id_col]
         if has_cpv:
             insert_cols = table_base_cols + [
                 "principal_prefix4",
@@ -819,9 +805,7 @@ def load_parquet_to_l0(
                             if _scalar_isna(v):
                                 vals.append(None)
                                 continue
-                            pg_type = next(
-                                (t for col, t in column_defs if col == c), "TEXT"
-                            )
+                            pg_type = next((t for col, t in column_defs if col == c), "TEXT")
                             if "INT" in pg_type or "BIGINT" in pg_type:
                                 try:
                                     vals.append(int(v))
@@ -835,9 +819,7 @@ def load_parquet_to_l0(
                             elif "BOOL" in pg_type:
                                 vals.append(bool(v) if v is not None else None)
                             elif "JSONB" in pg_type:
-                                vals.append(
-                                    psycopg2.extras.Json(_convert_numpy_to_python(v))
-                                )
+                                vals.append(psycopg2.extras.Json(_convert_numpy_to_python(v)))
                             else:
                                 vals.append(v)
                         rows.append(tuple(vals))
@@ -893,20 +875,12 @@ def load_parquet_to_l0(
                                         vals.append(int(v))
                                     except (TypeError, ValueError):
                                         vals.append(None)
-                                elif isinstance(v, (list, dict)) or hasattr(
-                                    v, "tolist"
-                                ):
-                                    vals.append(
-                                        psycopg2.extras.Json(
-                                            _convert_numpy_to_python(v)
-                                        )
-                                    )
+                                elif isinstance(v, (list, dict)) or hasattr(v, "tolist"):
+                                    vals.append(psycopg2.extras.Json(_convert_numpy_to_python(v)))
                                 else:
                                     vals.append(v)
                             else:
-                                pg_type = next(
-                                    (t for col, t in column_defs if col == c), "TEXT"
-                                )
+                                pg_type = next((t for col, t in column_defs if col == c), "TEXT")
                                 if "INT" in pg_type or "BIGINT" in pg_type:
                                     try:
                                         vals.append(int(v))
@@ -920,11 +894,7 @@ def load_parquet_to_l0(
                                 elif "BOOL" in pg_type:
                                     vals.append(bool(v))
                                 elif "JSONB" in pg_type:
-                                    vals.append(
-                                        psycopg2.extras.Json(
-                                            _convert_numpy_to_python(v)
-                                        )
-                                    )
+                                    vals.append(psycopg2.extras.Json(_convert_numpy_to_python(v)))
                                 else:
                                     vals.append(v)
                         if has_cpv:

--- a/etl/ingest_l0.py
+++ b/etl/ingest_l0.py
@@ -131,8 +131,6 @@ SUBVENCIONES_PARQUET_COLUMNS = [
     # Fechas de solicitud
     ("fecha_inicio_solicitud", "DATE"),
     ("fecha_fin_solicitud", "DATE"),
-    ("text_inicio", "TEXT"),
-    ("text_fin", "TEXT"),
     # Ayuda de estado
     ("ayuda_estado", "TEXT"),
     ("url_ayuda_estado", "TEXT"),

--- a/etl/ingest_l0.py
+++ b/etl/ingest_l0.py
@@ -689,7 +689,7 @@ def load_parquet_to_l0(
         raise FileNotFoundError(f"Parquet no encontrado: {parquet_path}")
 
     df = pd.read_parquet(parquet_path)
-    logger.info("Parquet cargado: %s filas.", len(df))
+    logger.info("Parquet cargado: %s filas, cargando en base de datos...", len(df))
 
     if column_defs is None:
         column_defs = NACIONAL_PARQUET_COLUMNS
@@ -757,7 +757,6 @@ def load_parquet_to_l0(
 
     # Build INSERT statement based on dataset type
     if is_subvenciones:
-        logger.info("Ingestando subvenciones en la base de datos...")
         insert_cols = [c for c, _ in column_defs]
         placeholders = ", ".join(["%s"] * len(insert_cols))
         quoted = ", ".join(f'"{c}"' for c in insert_cols)
@@ -933,10 +932,4 @@ def load_parquet_to_l0(
                         inserted += cur.rowcount or 0
                     conn.commit()
     skipped = total_candidates - inserted
-
-    logger.info(
-        "Ingesta completada: %s filas insertadas, %s omitidas (ya existentes).",
-        inserted,
-        skipped,
-    )
     return (inserted, skipped)

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -280,7 +280,7 @@ def scrape_historico(params: SearchParams) -> list[Path]:
     params.validate()
 
     _ensure_output_dir()
-    rate_limiter = RateLimiter(max_requests=40, time_window=60)
+    rate_limiter = RateLimiter(max_requests=59, time_window=60)
 
     _log("INFO", "=" * 60)
     _log("INFO", "SUBVENCIONES HISTÓRICAS (BDNS)")
@@ -367,7 +367,7 @@ def scrape_historico(params: SearchParams) -> list[Path]:
                 if col in df.columns:
                     df[col] = df[col].apply(lambda x: json.dumps(x) if x is not None else None)
 
-            parquet_filename = f"_part_subvenciones_{batch_number:04d}.parquet"
+            parquet_filename = f"_part_subvenciones_{batch_number:03d}.parquet"
             parquet_path = OUTPUT_DIR / parquet_filename
 
             df.to_parquet(parquet_path, engine="pyarrow", index=False)
@@ -445,7 +445,7 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
     total_new = 0
     total_duplicates = 0
     total_filtered = 0
-    rate_limiter = RateLimiter(max_requests=40, time_window=60)
+    rate_limiter = RateLimiter(max_requests=49, time_window=60)
     subvencion_pattern = re.compile(r"subvenci[oó]n", re.IGNORECASE)
 
     _log("INFO", "Actualizando subvenciones diarias...")

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -76,10 +76,6 @@ class RateLimiter:
             wait_time = self.time_window - (now - oldest_request)
 
             if wait_time > 0:
-                _log(
-                    "WARN",
-                    f"Límite de peticiones alcanzado. Esperando {wait_time:.1f}s...",
-                )
                 time.sleep(wait_time + 0.1)
                 now = time.time()
                 self.request_times = [t for t in self.request_times if now - t < self.time_window]
@@ -284,19 +280,19 @@ def scrape_historico(params: SearchParams) -> list[Path]:
     params.validate()
 
     _ensure_output_dir()
-    rate_limiter = RateLimiter(max_requests=40, time_window=60)  # Conservative limit to avoid 429s
+    rate_limiter = RateLimiter(max_requests=40, time_window=60)
 
-    print(f"\n{'='*60}", flush=True)
-    print(f"SUBVENCIONES HISTÓRICAS (BDNS)", flush=True)
-    print(f"   Rango: {params.fechaDesde} — {params.fechaHasta}", flush=True)
-    print(f"{'='*60}\n", flush=True)
+    _log("INFO", "=" * 60)
+    _log("INFO", "SUBVENCIONES HISTÓRICAS (BDNS)")
+    _log("INFO", f"Rango: {params.fechaDesde} — {params.fechaHasta}")
+    _log("INFO", "=" * 60)
 
     try:
         light_convocatorias = []
         page = 0
         is_last_page = False
 
-        print("Obteniendo lista de convocatorias...", flush=True)
+        _log("INFO", "Obteniendo lista de convocatorias...")
         with tqdm(desc="Páginas", unit="pag") as pbar:
             while not is_last_page:
                 params.page = page
@@ -337,13 +333,13 @@ def scrape_historico(params: SearchParams) -> list[Path]:
                 page += 1
                 pbar.update(1)
 
-        print(f"INFO {len(light_convocatorias):,} convocatorias obtenidas\n", flush=True)
+        _log("INFO", f"{len(light_convocatorias):,} convocatorias obtenidas")
 
-        print("Obteniendo detalles de convocatorias...", flush=True)
+        _log("INFO", "Obteniendo detalles de convocatorias...")
         detailed_records = []
         failed_count = 0
 
-        for conv in tqdm(light_convocatorias, desc="Detalles", unit="conv"):
+        for conv in tqdm(light_convocatorias, unit="conv"):
             try:
                 result = fetch_convocatoria_detalle(conv["numero_convocatoria"], rate_limiter)
                 if result:
@@ -355,15 +351,12 @@ def scrape_historico(params: SearchParams) -> list[Path]:
                 failed_count += 1
 
         if failed_count > 0:
-            print(f"{failed_count} convocatorias fallaron", flush=True)
+            _log("WARN", f"{failed_count} convocatorias fallaron")
 
         if not detailed_records:
             raise ValueError("No se obtuvieron registros detallados")
 
-        print(f"INFO {len(detailed_records):,} registros detallados obtenidos\n", flush=True)
-
-        # Fase 3: Generar parquets en batches
-        print(f"Generando parquets (máx {MAX_RECORDS_PER_PARQUET:,} por archivo)...", flush=True)
+        _log("INFO", f"Generando parquets (máx {MAX_RECORDS_PER_PARQUET:,} por archivo)...")
         parquet_paths = []
 
         for batch_idx in range(0, len(detailed_records), MAX_RECORDS_PER_PARQUET):
@@ -395,15 +388,15 @@ def scrape_historico(params: SearchParams) -> list[Path]:
             parquet_paths.append(parquet_path)
 
             size_mb = parquet_path.stat().st_size / (1024 * 1024)
-            print(
-                f"INFO {parquet_path.name} ({len(df):,} registros guardados, {size_mb:.1f} MB)",
-                flush=True,
+            _log(
+                "INFO",
+                f"{parquet_path.name} ({len(df):,} registros guardados, {size_mb:.1f} MB)",
             )
 
         return parquet_paths
 
     except Exception as err:
-        print(f"\nERROR: {err}\n", flush=True)
+        _log("ERROR", str(err))
         raise
 
 
@@ -433,10 +426,10 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
     total_new = 0
     total_duplicates = 0
     total_filtered = 0
-    rate_limiter = RateLimiter(max_requests=40, time_window=60)  # Conservative limit to avoid 429s
+    rate_limiter = RateLimiter(max_requests=40, time_window=60)
     subvencion_pattern = re.compile(r"subvenci[oó]n", re.IGNORECASE)
 
-    print(f"\nActualizando subvenciones diarias...\n", flush=True)
+    _log("INFO", "Actualizando subvenciones diarias...")
 
     try:
         conn = psycopg2.connect(db_url)
@@ -603,9 +596,9 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
 
             page += 1
 
-        print(
-            f"\nCOMPLETADO: {total_new} nuevos, {total_duplicates} duplicados, {total_filtered} filtrados\n",
-            flush=True,
+        _log(
+            "INFO",
+            f"COMPLETADO: {total_new} nuevos, {total_duplicates} duplicados, {total_filtered} filtrados",
         )
 
         return {
@@ -616,7 +609,7 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
         }
 
     except Exception as err:
-        print(f"\nERROR: {err}\n", flush=True)
+        _log("ERROR", str(err))
         if conn:
             conn.rollback()
         raise
@@ -660,8 +653,8 @@ def main():
 
     fecha_desde = f"01/01/{ano_inicio}"
 
-    print(f"   Fechas: {fecha_desde} - {fecha_hasta}")
-    print(f"   Conjunto: {args.conjunto}")
+    _log("INFO", f"Fechas: {fecha_desde} - {fecha_hasta}")
+    _log("INFO", f"Conjunto: {args.conjunto}")
 
     try:
         params = SearchParams(
@@ -673,10 +666,10 @@ def main():
 
         parquet_paths = scrape_historico(params)
         if args.solo_descargar:
-            print(f"   (--solo-descargar: no se cargará en BD)")
-            print(f"   Archivos generados: {len(parquet_paths)}")
+            _log("INFO", "(--solo-descargar: no se cargará en BD)")
+            _log("INFO", f"Archivos generados: {len(parquet_paths)}")
             for path in parquet_paths:
-                print(f"     - {path.name}")
+                _log("INFO", f"  - {path.name}")
 
         return 0
 

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -12,6 +12,8 @@ import argparse
 import re
 import json
 from tqdm import tqdm
+import threading
+from queue import Queue
 
 LOG_PREFIX = "[subvenciones]"
 
@@ -45,39 +47,6 @@ OUTPUT_DIR = _tmp_base / "output"
 def _ensure_output_dir():
     """Ensure output directory exists."""
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-
-
-@dataclass
-class RateLimiter:
-    """Manage API rate limiting to avoid exceeding request limits and get API ban."""
-
-    max_requests: int = field(default=50)
-    time_window: int = field(default=60)
-    request_times: list = field(default_factory=list, init=False)
-
-    def wait_if_needed(self):
-        """Wait if necessary to avoid exceeding rate limit."""
-        now = time.time()
-
-        # Remove requests outside the current time window
-        self.request_times = [t for t in self.request_times if now - t < self.time_window]
-
-        # Check if we've reached the limit
-        if len(self.request_times) >= self.max_requests:
-            # Calculate how long to wait
-            oldest_request = self.request_times[0]
-            wait_time = self.time_window - (now - oldest_request)
-
-            if wait_time > 0:
-                time.sleep(wait_time + 0.1)
-                now = time.time()
-                self.request_times = [t for t in self.request_times if now - t < self.time_window]
-
-        self.request_times.append(time.time())
-
-    def reset(self):
-        """Reset the rate limiter."""
-        self.request_times = []
 
 
 @dataclass
@@ -170,14 +139,13 @@ def _convert_to_json_serializable(obj):
 
 def fetch_convocatoria_detalle(
     numero_convocatoria: str,
-    rate_limiter: RateLimiter,
 ) -> dict | None:
     """
     Fetch detailed information for a single convocatoria.
+    Implements progressive retry with 4 attempts: 5s, 15s, 25s, 40s delays.
 
     Args:
         numero_convocatoria: The convocatoria number to fetch details for
-        rate_limiter: RateLimiter instance
 
     Returns:
         Dictionary with detailed convocatoria data or None if error
@@ -187,69 +155,101 @@ def fetch_convocatoria_detalle(
         "numConv": numero_convocatoria,
     }
 
-    try:
-        rate_limiter.wait_if_needed()
-        res = requests.get(API_ENDPOINT_DETAIL, params=params, timeout=30)
+    max_retries = 4
+    retry_delays = [5, 15, 25, 40]  # Progressive delays in seconds
 
-        if res.status_code != 200:
-            _log(
-                "WARN",
-                f"Error al obtener detalle de convocatoria {numero_convocatoria}: HTTP {res.status_code}",
-            )
-            return None
+    for attempt in range(max_retries):
+        try:
+            res = requests.get(API_ENDPOINT_DETAIL, params=params, timeout=30)
 
-        data = res.json()
+            if res.status_code == 429:
+                if attempt < max_retries - 1:
+                    delay = retry_delays[attempt]
+                    _log(
+                        "WARN",
+                        f"HTTP 429 para convocatoria {numero_convocatoria}, esperando {delay}s antes de reintentar (intento {attempt + 1}/{max_retries})...",
+                    )
+                    time.sleep(delay)
+                    continue
+                else:
+                    _log(
+                        "ERROR",
+                        f"HTTP 429 para convocatoria {numero_convocatoria} después de {max_retries} intentos",
+                    )
+                    return None
 
-        # Flatten organo
-        organo = data.get("organo", {})
-        nivel1, nivel2, nivel3 = _flatten_organo(organo)
+            if res.status_code != 200:
+                _log(
+                    "WARN",
+                    f"Error al obtener detalle de convocatoria {numero_convocatoria}: HTTP {res.status_code}",
+                )
+                return None
 
-        # Build flattened record
-        record = {
-            "id": data.get("id"),
-            "nivel1": nivel1,
-            "nivel2": nivel2,
-            "nivel3": nivel3,
-            "sede_electronica": data.get("sedeElectronica"),
-            "codigo_bdns": data.get("codigoBDNS"),
-            "fecha_recepcion": data.get("fechaRecepcion"),
-            "instrumentos": _convert_to_json_serializable(data.get("instrumentos")),
-            "tipo_convocatoria": data.get("tipoConvocatoria"),
-            "presupuesto_total": data.get("presupuestoTotal"),
-            "mrr": data.get("mrr"),
-            "descripcion": data.get("descripcion"),
-            "descripcion_leng": data.get("descripcionLeng"),
-            "tipos_beneficiarios": _convert_to_json_serializable(data.get("tiposBeneficiarios")),
-            "sectores": _convert_to_json_serializable(data.get("sectores")),
-            "regiones": _convert_to_json_serializable(data.get("regiones")),
-            "descripcion_finalidad": data.get("descripcionFinalidad"),
-            "descripcion_bases_reguladoras": data.get("descripcionBasesReguladoras"),
-            "url_bases_reguladoras": data.get("urlBasesReguladoras"),
-            "se_publica_diario_oficial": data.get("sePublicaDiarioOficial"),
-            "abierto": data.get("abierto"),
-            "fecha_inicio_solicitud": data.get("fechaInicioSolicitud"),
-            "fecha_fin_solicitud": data.get("fechaFinSolicitud"),
-            "text_inicio": data.get("textInicio"),
-            "text_fin": data.get("textFin"),
-            "ayuda_estado": data.get("ayudaEstado"),
-            "url_ayuda_estado": data.get("urlAyudaEstado"),
-            "fondos": _convert_to_json_serializable(data.get("fondos")),
-            "reglamento": _convert_to_json_serializable(data.get("reglamento")),
-            "objetivos": _convert_to_json_serializable(data.get("objetivos")),
-            "sectores_productos": _convert_to_json_serializable(data.get("sectoresProductos")),
-            "documentos": _convert_to_json_serializable(data.get("documentos")),
-            "anuncios": _convert_to_json_serializable(data.get("anuncios")),
-            "advertencia": data.get("advertencia"),
-        }
+            data = res.json()
 
-        return record
+            # Flatten organo
+            organo = data.get("organo", {})
+            nivel1, nivel2, nivel3 = _flatten_organo(organo)
 
-    except Exception as e:
-        _log(
-            "ERROR",
-            f"Excepción al obtener detalle de convocatoria {numero_convocatoria}: {e}",
-        )
-        return None
+            # Build flattened record
+            record = {
+                "id": data.get("id"),
+                "nivel1": nivel1,
+                "nivel2": nivel2,
+                "nivel3": nivel3,
+                "sede_electronica": data.get("sedeElectronica"),
+                "codigo_bdns": data.get("codigoBDNS"),
+                "fecha_recepcion": data.get("fechaRecepcion"),
+                "instrumentos": _convert_to_json_serializable(data.get("instrumentos")),
+                "tipo_convocatoria": data.get("tipoConvocatoria"),
+                "presupuesto_total": data.get("presupuestoTotal"),
+                "mrr": data.get("mrr"),
+                "descripcion": data.get("descripcion"),
+                "descripcion_leng": data.get("descripcionLeng"),
+                "tipos_beneficiarios": _convert_to_json_serializable(
+                    data.get("tiposBeneficiarios")
+                ),
+                "sectores": _convert_to_json_serializable(data.get("sectores")),
+                "regiones": _convert_to_json_serializable(data.get("regiones")),
+                "descripcion_finalidad": data.get("descripcionFinalidad"),
+                "descripcion_bases_reguladoras": data.get("descripcionBasesReguladoras"),
+                "url_bases_reguladoras": data.get("urlBasesReguladoras"),
+                "se_publica_diario_oficial": data.get("sePublicaDiarioOficial"),
+                "abierto": data.get("abierto"),
+                "fecha_inicio_solicitud": data.get("fechaInicioSolicitud"),
+                "fecha_fin_solicitud": data.get("fechaFinSolicitud"),
+                "text_inicio": data.get("textInicio"),
+                "text_fin": data.get("textFin"),
+                "ayuda_estado": data.get("ayudaEstado"),
+                "url_ayuda_estado": data.get("urlAyudaEstado"),
+                "fondos": _convert_to_json_serializable(data.get("fondos")),
+                "reglamento": _convert_to_json_serializable(data.get("reglamento")),
+                "objetivos": _convert_to_json_serializable(data.get("objetivos")),
+                "sectores_productos": _convert_to_json_serializable(data.get("sectoresProductos")),
+                "documentos": _convert_to_json_serializable(data.get("documentos")),
+                "anuncios": _convert_to_json_serializable(data.get("anuncios")),
+                "advertencia": data.get("advertencia"),
+            }
+
+            return record
+
+        except Exception as e:
+            if attempt < max_retries - 1:
+                delay = retry_delays[attempt]
+                _log(
+                    "WARN",
+                    f"Excepción al obtener convocatoria {numero_convocatoria} (intento {attempt + 1}/{max_retries}): {e}, esperando {delay}s...",
+                )
+                time.sleep(delay)
+                continue
+            else:
+                _log(
+                    "ERROR",
+                    f"Excepción al obtener detalle de convocatoria {numero_convocatoria}: {e}",
+                )
+                return None
+
+    return None
 
 
 def scrape_historico(params: SearchParams) -> list[Path]:
@@ -272,8 +272,6 @@ def scrape_historico(params: SearchParams) -> list[Path]:
     params.validate()
 
     _ensure_output_dir()
-    # Rate limiter: endpoint de detalles tiene límite ~20 req/min
-    rate_limiter = RateLimiter(max_requests=20, time_window=60)
 
     _log("INFO", "=" * 60)
     _log("INFO", "SUBVENCIONES HISTÓRICAS (BDNS)")
@@ -289,7 +287,6 @@ def scrape_historico(params: SearchParams) -> list[Path]:
         with tqdm(desc="Páginas", unit="pag") as pbar:
             while not is_last_page:
                 params.page = page
-                rate_limiter.wait_if_needed()
                 res = requests.get(API_ENDPOINT_SEARCH, params=params.to_dict())
 
                 if res.status_code != 200:
@@ -327,13 +324,18 @@ def scrape_historico(params: SearchParams) -> list[Path]:
                 pbar.update(1)
 
         _log("INFO", f"{len(light_convocatorias):,} convocatorias obtenidas")
-        _log("INFO", "Obteniendo detalles y generando parquets (modo secuencial)...")
+        _log(
+            "INFO",
+            "Obteniendo detalles y generando parquets (modo pipeline: 1 fetcher + 1 saver)...",
+        )
 
-        batch_buffer = []
+        buffer = Queue(maxsize=100)
+        stats_lock = threading.Lock()
         failed_count = 0
         parquet_paths = []
-        batch_num = 0
-        total_saved = 0
+        batch_num = [0]  # Shared between threads
+        total_saved = [0]  # Shared between threads
+        fetching_done = threading.Event()
 
         jsonb_cols = [
             "instrumentos",
@@ -371,31 +373,67 @@ def scrape_historico(params: SearchParams) -> list[Path]:
             )
             return parquet_path
 
-        # Modo secuencial - procesar todas las convocatorias
-        for conv in tqdm(light_convocatorias, unit="conv"):
-            try:
-                result = fetch_convocatoria_detalle(conv["numero_convocatoria"], rate_limiter)
-                if result:
-                    batch_buffer.append(result)
+        def fetcher():
+            """Thread 1: fetch + preprocesar → buffer."""
+            nonlocal failed_count
+            for conv in tqdm(light_convocatorias, unit="conv", desc="Fetch+Preproc"):
+                try:
+                    result = fetch_convocatoria_detalle(conv["numero_convocatoria"])
+                    if result:
+                        buffer.put(result)
+                    else:
+                        with stats_lock:
+                            failed_count += 1
+                except Exception as e:
+                    _log("ERROR", f"Excepción: {e}")
+                    with stats_lock:
+                        failed_count += 1
+            fetching_done.set()
+
+        def saver():
+            """Thread 2: buffer → batch → guardar parquet."""
+            batch_buffer = []
+
+            while not (fetching_done.is_set() and buffer.empty()):
+                try:
+                    record = buffer.get(timeout=1)
+                    batch_buffer.append(record)
 
                     if len(batch_buffer) >= MAX_RECORDS_PER_PARQUET:
-                        parquet_path = save_batch(batch_buffer, batch_num)
+                        with stats_lock:
+                            current_batch = batch_num[0]
+                            batch_num[0] += 1
+
+                        parquet_path = save_batch(batch_buffer, current_batch)
                         if parquet_path:
                             parquet_paths.append(parquet_path)
-                            total_saved += len(batch_buffer)
+                            with stats_lock:
+                                total_saved[0] += len(batch_buffer)
                         batch_buffer = []
-                        batch_num += 1
-                else:
-                    failed_count += 1
-            except Exception as e:
-                _log("ERROR", f"Excepción: {e}")
-                failed_count += 1
 
-        if batch_buffer:
-            parquet_path = save_batch(batch_buffer, batch_num)
-            if parquet_path:
-                parquet_paths.append(parquet_path)
-                total_saved += len(batch_buffer)
+                    buffer.task_done()
+                except:
+                    pass
+
+            # Guardar último batch
+            if batch_buffer:
+                with stats_lock:
+                    current_batch = batch_num[0]
+                    batch_num[0] += 1
+
+                parquet_path = save_batch(batch_buffer, current_batch)
+                if parquet_path:
+                    parquet_paths.append(parquet_path)
+                    with stats_lock:
+                        total_saved[0] += len(batch_buffer)
+
+        # Iniciar threads
+        t1 = threading.Thread(target=fetcher)
+        t2 = threading.Thread(target=saver)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
 
         if failed_count > 0:
             _log("WARN", f"{failed_count} convocatorias fallaron")
@@ -403,7 +441,7 @@ def scrape_historico(params: SearchParams) -> list[Path]:
         if not parquet_paths:
             raise ValueError("No se generaron parquets (sin registros válidos)")
 
-        _log("INFO", f"{total_saved:,} registros guardados en {len(parquet_paths)} parquets")
+        _log("INFO", f"{total_saved[0]:,} registros guardados en {len(parquet_paths)} parquets")
 
         return parquet_paths
 
@@ -438,8 +476,6 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
     total_new = 0
     total_duplicates = 0
     total_filtered = 0
-    # Rate limiter: endpoint de detalles tiene límite ~20 req/min
-    rate_limiter = RateLimiter(max_requests=20, time_window=60)
     subvencion_pattern = re.compile(r"subvenci[oó]n", re.IGNORECASE)
 
     _log("INFO", "Actualizando subvenciones diarias...")
@@ -453,7 +489,6 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
         while not is_last_page:
             params.page = page
 
-            rate_limiter.wait_if_needed()
             res = requests.get(API_ENDPOINT_LATEST, params=params.to_dict())
 
             if res.status_code != 200:
@@ -518,11 +553,11 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
                     page += 1
                     continue
 
-                # Fetch details for new convocatorias (sequential, no ThreadPool)
+                # Fetch details for new convocatorias (sequential, opción 1)
                 detailed_records = []
                 _log("INFO", "Obteniendo detalles de convocatorias...")
                 for conv in tqdm(new_convocatorias, unit="conv"):
-                    detail = fetch_convocatoria_detalle(conv["numero_convocatoria"], rate_limiter)
+                    detail = fetch_convocatoria_detalle(conv["numero_convocatoria"])
                     if detail:
                         detailed_records.append(detail)
 
@@ -667,7 +702,7 @@ def main():
         fecha_hasta = datetime.now().strftime("%d/%m/%Y")
 
     # fecha_desde = f"01/01/{ano_inicio}"
-    fecha_desde = f"16/04/2026"
+    fecha_desde = f"10/04/2026"
     _log("INFO", f"Fechas: {fecha_desde} - {fecha_hasta}")
     _log("INFO", f"Conjunto: {args.conjunto}")
 

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -293,52 +293,47 @@ def scrape_historico(params: SearchParams) -> list[Path]:
         is_last_page = False
 
         _log("INFO", "Obteniendo lista de convocatorias...")
-        with tqdm(desc="Páginas", unit="pag") as pbar:
-            while not is_last_page:
-                params.page = page
-                res = requests.get(API_ENDPOINT_SEARCH, params=params.to_dict())
+        while not is_last_page:
+            params.page = page
+            res = requests.get(API_ENDPOINT_SEARCH, params=params.to_dict())
 
-                if res.status_code != 200:
-                    try:
-                        error_data = res.json()
-                        if "errores" in error_data:
-                            error_msgs = "\n  - ".join(error_data["errores"])
-                            raise ValueError(
-                                f"Error de la API ({error_data.get('codigo', 'UNKNOWN')}):\n  {error_msgs}"
-                            )
-                    except ValueError:
-                        raise
-                    except Exception:
-                        res.raise_for_status()
-
-                data = res.json()
-                content = data.get("content", [])
-                is_last_page = data.get("last", True)
-
-                if page == 0:
-                    pbar.total = data.get("totalPages", 0)
-
-                if not content:
-                    break
-
-                for item in content:
-                    # Convert numeroConvocatoria to int for consistent type handling
-                    numero_conv = item.get("numeroConvocatoria")
-                    if numero_conv:
-                        light_convocatorias.append(
-                            {
-                                "id": item.get("id"),
-                                "numero_convocatoria": int(numero_conv),
-                            }
+            if res.status_code != 200:
+                try:
+                    error_data = res.json()
+                    if "errores" in error_data:
+                        error_msgs = "\n  - ".join(error_data["errores"])
+                        raise ValueError(
+                            f"Error de la API ({error_data.get('codigo', 'UNKNOWN')}):\n  {error_msgs}"
                         )
+                except ValueError:
+                    raise
+                except Exception:
+                    res.raise_for_status()
 
-                page += 1
-                pbar.update(1)
+            data = res.json()
+            content = data.get("content", [])
+            is_last_page = data.get("last", True)
 
-        _log("INFO", f"{len(light_convocatorias):,} convocatorias obtenidas")
+            if not content:
+                break
+
+            for item in content:
+                # Convert numeroConvocatoria to int for consistent type handling
+                numero_conv = item.get("numeroConvocatoria")
+                if numero_conv:
+                    light_convocatorias.append(
+                        {
+                            "id": item.get("id"),
+                            "numero_convocatoria": int(numero_conv),
+                        }
+                    )
+
+            page += 1
+
+        _log("INFO", f"{len(light_convocatorias):,} convocatorias obtenidas\n")
         _log(
             "INFO",
-            "Obteniendo detalles y generando parquets (modo pipeline: 1 fetcher + 1 saver)...",
+            "Obteniendo detalles y generando parquets...",
         )
 
         buffer = Queue(maxsize=100)
@@ -486,16 +481,18 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
     total_filtered = 0
     subvencion_pattern = re.compile(r"subvenci[oó]n", re.IGNORECASE)
 
-    _log("INFO", "Actualizando subvenciones diarias...")
+    _log("INFO", "Obteniendo convocatorias nuevas...")
 
     try:
         conn = psycopg2.connect(db_url)
-        cur = conn.cursor()  # Open cursor once at the start
+        cur = conn.cursor()
 
+        all_new_convocatorias = []
         page = params.page
         is_last_page = False
+        found_duplicates = False
 
-        while not is_last_page:
+        while not is_last_page and not found_duplicates:
             params.page = page
 
             res = requests.get(API_ENDPOINT_LATEST, params=params.to_dict())
@@ -514,7 +511,6 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
                     res.raise_for_status()
 
             data = res.json()
-
             content = data.get("content", [])
             is_last_page = data.get("last", True)
 
@@ -529,7 +525,6 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
                 if not subvencion_pattern.search(descripcion):
                     page_filtered += 1
                     continue
-                # Convert numeroConvocatoria to int for consistent type comparison
                 numero_conv = item.get("numeroConvocatoria")
                 if numero_conv:
                     light_convocatorias.append(
@@ -544,7 +539,7 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
                 page += 1
                 continue
 
-            # Check for duplicates using the persistent cursor
+            # Check for duplicates
             cur.execute(
                 "SELECT id FROM l0.nacional_subvenciones WHERE id = ANY(%s)",
                 ([conv["numero_convocatoria"] for conv in light_convocatorias],),
@@ -556,120 +551,124 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
                 for conv in light_convocatorias
                 if conv["numero_convocatoria"] not in existing_ids
             ]
-            page_dups = len(existing_ids)
-            total_duplicates += page_dups
+            total_duplicates += len(existing_ids)
 
-            # Show progress message for this page
-            _log(
-                "INFO",
-                f"Para la página número {page + 1} se han encontrado {len(new_convocatorias)} convocatorias nuevas",
-            )
+            # Add new convocatorias to the accumulated list
+            all_new_convocatorias.extend(new_convocatorias)
 
-            if not new_convocatorias:
-                # If we found duplicates, stop searching
-                if existing_ids:
-                    _log("INFO", "Ya se encontraron todas las convocatorias recientes")
-                    break
-                page += 1
-                continue
-
-            detailed_records = []
-            for conv in new_convocatorias:
-                # Convert back to string for API request
-                detail = fetch_convocatoria_detalle(str(conv["numero_convocatoria"]))
-                if detail:
-                    detailed_records.append(detail)
-
-            if not detailed_records:
-                page += 1
-                continue
-
-            records_to_insert = []
-            for record in detailed_records:
-                # Serialize JSONB columns
-                jsonb_cols = [
-                    "instrumentos",
-                    "tipos_beneficiarios",
-                    "sectores",
-                    "regiones",
-                    "fondos",
-                    "reglamento",
-                    "objetivos",
-                    "sectores_productos",
-                    "documentos",
-                    "anuncios",
-                ]
-                for col in jsonb_cols:
-                    if record.get(col) is not None:
-                        record[col] = json.dumps(record[col])
-
-                records_to_insert.append(
-                    (
-                        record.get("id"),
-                        record.get("nivel1"),
-                        record.get("nivel2"),
-                        record.get("nivel3"),
-                        record.get("sede_electronica"),
-                        record.get("codigo_bdns"),
-                        record.get("fecha_recepcion"),
-                        record.get("instrumentos"),
-                        record.get("tipo_convocatoria"),
-                        record.get("presupuesto_total"),
-                        record.get("mrr"),
-                        record.get("descripcion"),
-                        record.get("descripcion_leng"),
-                        record.get("tipos_beneficiarios"),
-                        record.get("regiones"),
-                        record.get("sectores"),
-                        record.get("descripcion_finalidad"),
-                        record.get("descripcion_bases_reguladoras"),
-                        record.get("url_bases_reguladoras"),
-                        record.get("se_publica_diario_oficial"),
-                        record.get("abierto"),
-                        record.get("fecha_inicio_solicitud"),
-                        record.get("fecha_fin_solicitud"),
-                        record.get("text_inicio"),
-                        record.get("text_fin"),
-                        record.get("ayuda_estado"),
-                        record.get("url_ayuda_estado"),
-                        record.get("fondos"),
-                        record.get("reglamento"),
-                        record.get("objetivos"),
-                        record.get("sectores_productos"),
-                        record.get("documentos"),
-                        record.get("anuncios"),
-                    )
-                )
-
-            # Insert using the persistent cursor
-            insert_sql = """
-                INSERT INTO l0.nacional_subvenciones 
-                (id, nivel1, nivel2, nivel3, sede_electronica, codigo_bdns, fecha_recepcion,
-                 instrumentos, tipo_convocatoria, presupuesto_total, mrr, descripcion, descripcion_leng,
-                 tipos_beneficiarios, sectores, regiones, descripcion_finalidad, descripcion_bases_reguladoras,
-                 url_bases_reguladoras, se_publica_diario_oficial, abierto, fecha_inicio_solicitud,
-                 fecha_fin_solicitud, text_inicio, text_fin, ayuda_estado, url_ayuda_estado,
-                 fondos, reglamento, objetivos, sectores_productos, documentos, anuncios)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                ON CONFLICT (id) DO NOTHING
-            """
-
-            execute_batch(cur, insert_sql, records_to_insert)
-            conn.commit()
-
-            _log("INFO", f"  Insertados {len(records_to_insert)} registros en BD")
-            total_new += len(records_to_insert)
-
+            # Stop if we found duplicates (means we reached already processed data)
             if existing_ids:
-                _log("INFO", "Ya se encontraron todas las convocatorias recientes")
+                found_duplicates = True
                 break
 
             page += 1
 
+        if not all_new_convocatorias:
+            _log("INFO", "No hay convocatorias nuevas")
+            return {
+                "inserted": 0,
+                "omitted": total_duplicates,
+                "filtered": total_filtered,
+                "pages": page + 1,
+            }
+
         _log(
             "INFO",
-            f"COMPLETADO: {total_new} nuevos, {total_duplicates} duplicados, {total_filtered} filtrados",
+            f"{len(all_new_convocatorias)} convocatorias nuevas encontradas, guardando en BD...",
         )
+
+        # FASE 2: Obtener detalles de todas las convocatorias e insertar
+        detailed_records = []
+        for conv in all_new_convocatorias:
+            detail = fetch_convocatoria_detalle(str(conv["numero_convocatoria"]))
+            if detail:
+                detailed_records.append(detail)
+
+        if not detailed_records:
+            _log("INFO", "No se pudieron obtener detalles de las convocatorias")
+            return {
+                "inserted": 0,
+                "omitted": total_duplicates,
+                "filtered": total_filtered,
+                "pages": page + 1,
+            }
+
+        # Prepare all records for insertion
+        records_to_insert = []
+        jsonb_cols = [
+            "instrumentos",
+            "tipos_beneficiarios",
+            "sectores",
+            "regiones",
+            "fondos",
+            "reglamento",
+            "objetivos",
+            "sectores_productos",
+            "documentos",
+            "anuncios",
+        ]
+
+        for record in detailed_records:
+            # Serialize JSONB columns
+            for col in jsonb_cols:
+                if record.get(col) is not None:
+                    record[col] = json.dumps(record[col])
+
+            records_to_insert.append(
+                (
+                    record.get("id"),
+                    record.get("nivel1"),
+                    record.get("nivel2"),
+                    record.get("nivel3"),
+                    record.get("sede_electronica"),
+                    record.get("codigo_bdns"),
+                    record.get("fecha_recepcion"),
+                    record.get("instrumentos"),
+                    record.get("tipo_convocatoria"),
+                    record.get("presupuesto_total"),
+                    record.get("mrr"),
+                    record.get("descripcion"),
+                    record.get("descripcion_leng"),
+                    record.get("tipos_beneficiarios"),
+                    record.get("regiones"),
+                    record.get("sectores"),
+                    record.get("descripcion_finalidad"),
+                    record.get("descripcion_bases_reguladoras"),
+                    record.get("url_bases_reguladoras"),
+                    record.get("se_publica_diario_oficial"),
+                    record.get("abierto"),
+                    record.get("fecha_inicio_solicitud"),
+                    record.get("fecha_fin_solicitud"),
+                    record.get("text_inicio"),
+                    record.get("text_fin"),
+                    record.get("ayuda_estado"),
+                    record.get("url_ayuda_estado"),
+                    record.get("fondos"),
+                    record.get("reglamento"),
+                    record.get("objetivos"),
+                    record.get("sectores_productos"),
+                    record.get("documentos"),
+                    record.get("anuncios"),
+                )
+            )
+
+        insert_sql = """
+            INSERT INTO l0.nacional_subvenciones 
+            (id, nivel1, nivel2, nivel3, sede_electronica, codigo_bdns, fecha_recepcion,
+             instrumentos, tipo_convocatoria, presupuesto_total, mrr, descripcion, descripcion_leng,
+             tipos_beneficiarios, sectores, regiones, descripcion_finalidad, descripcion_bases_reguladoras,
+             url_bases_reguladoras, se_publica_diario_oficial, abierto, fecha_inicio_solicitud,
+             fecha_fin_solicitud, text_inicio, text_fin, ayuda_estado, url_ayuda_estado,
+             fondos, reglamento, objetivos, sectores_productos, documentos, anuncios)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (id) DO NOTHING
+        """
+
+        execute_batch(cur, insert_sql, records_to_insert, page_size=100)
+        conn.commit()
+        total_new = len(records_to_insert)
+
+        _log("INFO", f"Actualizado con {total_new} convocatorias más recientes en BD")
 
         return {
             "inserted": total_new,

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -192,90 +192,107 @@ def _convert_to_json_serializable(obj):
 def fetch_convocatoria_detalle(
     numero_convocatoria: str,
     rate_limiter: RateLimiter,
+    max_retries: int = 5,
 ) -> dict | None:
     """
     Fetch detailed information for a single convocatoria.
 
+    Implements retry with exponential backoff for 429 errors (rate limit exceeded).
+
     Args:
         numero_convocatoria: The convocatoria number to fetch details for
         rate_limiter: RateLimiter instance (thread-safe)
-        vpd: VPD parameter (default: "GE")
+        max_retries: Maximum number of retries for 429 errors (default: 5)
 
     Returns:
-        Dictionary with detailed convocatoria data or None if error
+        Dictionary with detailed convocatoria data or None if error after all retries
     """
-    try:
-        rate_limiter.wait_if_needed()
+    params = {
+        "vpd": DEFAULT_VPD,
+        "numConv": numero_convocatoria,
+    }
 
-        params = {
-            "vpd": DEFAULT_VPD,
-            "numConv": numero_convocatoria,
-        }
+    for attempt in range(max_retries + 1):
+        try:
+            rate_limiter.wait_if_needed()
+            res = requests.get(API_ENDPOINT_DETAIL, params=params, timeout=30)
 
-        res = requests.get(API_ENDPOINT_DETAIL, params=params, timeout=30)
+            if res.status_code == 429:
+                # Rate limit exceeded - retry with exponential backoff
+                if attempt < max_retries:
+                    wait_time = (2**attempt) * 0.5  # 0.5s, 1s, 2s, 4s, 8s
+                    time.sleep(wait_time)
+                    continue
+                else:
+                    _log("WARN", f"Max retries alcanzado para {numero_convocatoria} (429)")
+                    return None
 
-        if res.status_code != 200:
+            if res.status_code != 200:
+                _log(
+                    "WARN",
+                    f"Error al obtener detalle de convocatoria {numero_convocatoria}: HTTP {res.status_code}",
+                )
+                return None
+
+            data = res.json()
+
+            # Flatten organo
+            organo = data.get("organo", {})
+            nivel1, nivel2, nivel3 = _flatten_organo(organo)
+
+            # Build flattened record
+            record = {
+                "id": data.get("id"),
+                "nivel1": nivel1,
+                "nivel2": nivel2,
+                "nivel3": nivel3,
+                "sede_electronica": data.get("sedeElectronica"),
+                "codigo_bdns": data.get("codigoBDNS"),
+                "fecha_recepcion": data.get("fechaRecepcion"),
+                "instrumentos": _convert_to_json_serializable(data.get("instrumentos")),
+                "tipo_convocatoria": data.get("tipoConvocatoria"),
+                "presupuesto_total": data.get("presupuestoTotal"),
+                "mrr": data.get("mrr"),
+                "descripcion": data.get("descripcion"),
+                "descripcion_leng": data.get("descripcionLeng"),
+                "tipos_beneficiarios": _convert_to_json_serializable(
+                    data.get("tiposBeneficiarios")
+                ),
+                "sectores": _convert_to_json_serializable(data.get("sectores")),
+                "regiones": _convert_to_json_serializable(data.get("regiones")),
+                "descripcion_finalidad": data.get("descripcionFinalidad"),
+                "descripcion_bases_reguladoras": data.get("descripcionBasesReguladoras"),
+                "url_bases_reguladoras": data.get("urlBasesReguladoras"),
+                "se_publica_diario_oficial": data.get("sePublicaDiarioOficial"),
+                "abierto": data.get("abierto"),
+                "fecha_inicio_solicitud": data.get("fechaInicioSolicitud"),
+                "fecha_fin_solicitud": data.get("fechaFinSolicitud"),
+                "text_inicio": data.get("textInicio"),
+                "text_fin": data.get("textFin"),
+                "ayuda_estado": data.get("ayudaEstado"),
+                "url_ayuda_estado": data.get("urlAyudaEstado"),
+                "fondos": _convert_to_json_serializable(data.get("fondos")),
+                "reglamento": _convert_to_json_serializable(data.get("reglamento")),
+                "objetivos": _convert_to_json_serializable(data.get("objetivos")),
+                "sectores_productos": _convert_to_json_serializable(data.get("sectoresProductos")),
+                "documentos": _convert_to_json_serializable(data.get("documentos")),
+                "anuncios": _convert_to_json_serializable(data.get("anuncios")),
+                "advertencia": data.get("advertencia"),
+            }
+
+            return record
+
+        except Exception as e:
             _log(
-                "WARN",
-                f"Error al obtener detalle de convocatoria {numero_convocatoria}: HTTP {res.status_code}",
+                "ERROR",
+                f"Excepción al obtener detalle de convocatoria {numero_convocatoria}: {e}",
             )
             return None
 
-        data = res.json()
-
-        # Flatten organo
-        organo = data.get("organo", {})
-        nivel1, nivel2, nivel3 = _flatten_organo(organo)
-
-        # Build flattened record
-        record = {
-            "id": data.get("id"),
-            "nivel1": nivel1,
-            "nivel2": nivel2,
-            "nivel3": nivel3,
-            "sede_electronica": data.get("sedeElectronica"),
-            "codigo_bdns": data.get("codigoBDNS"),
-            "fecha_recepcion": data.get("fechaRecepcion"),
-            "instrumentos": _convert_to_json_serializable(data.get("instrumentos")),
-            "tipo_convocatoria": data.get("tipoConvocatoria"),
-            "presupuesto_total": data.get("presupuestoTotal"),
-            "mrr": data.get("mrr"),
-            "descripcion": data.get("descripcion"),
-            "descripcion_leng": data.get("descripcionLeng"),
-            "tipos_beneficiarios": _convert_to_json_serializable(data.get("tiposBeneficiarios")),
-            "sectores": _convert_to_json_serializable(data.get("sectores")),
-            "regiones": _convert_to_json_serializable(data.get("regiones")),
-            "descripcion_finalidad": data.get("descripcionFinalidad"),
-            "descripcion_bases_reguladoras": data.get("descripcionBasesReguladoras"),
-            "url_bases_reguladoras": data.get("urlBasesReguladoras"),
-            "se_publica_diario_oficial": data.get("sePublicaDiarioOficial"),
-            "abierto": data.get("abierto"),
-            "fecha_inicio_solicitud": data.get("fechaInicioSolicitud"),
-            "fecha_fin_solicitud": data.get("fechaFinSolicitud"),
-            "text_inicio": data.get("textInicio"),
-            "text_fin": data.get("textFin"),
-            "ayuda_estado": data.get("ayudaEstado"),
-            "url_ayuda_estado": data.get("urlAyudaEstado"),
-            "fondos": _convert_to_json_serializable(data.get("fondos")),
-            "reglamento": _convert_to_json_serializable(data.get("reglamento")),
-            "objetivos": _convert_to_json_serializable(data.get("objetivos")),
-            "sectores_productos": _convert_to_json_serializable(data.get("sectoresProductos")),
-            "documentos": _convert_to_json_serializable(data.get("documentos")),
-            "anuncios": _convert_to_json_serializable(data.get("anuncios")),
-            "advertencia": data.get("advertencia"),
-        }
-
-        return record
-
-    except Exception as e:
-        _log(
-            "ERROR",
-            f"Excepción al obtener detalle de convocatoria {numero_convocatoria}: {e}",
-        )
-        return None
+    return None
 
 
-def scrape_historico(params: SearchParams, max_workers: int = 10) -> list[Path]:
+def scrape_historico(params: SearchParams, max_workers: int = 2) -> list[Path]:
     """
     Scrape historical grants data and save to Parquet files.
     This is for initial bulk load - generates Parquet files for etl/ingest_l0.py to process.
@@ -285,7 +302,7 @@ def scrape_historico(params: SearchParams, max_workers: int = 10) -> list[Path]:
 
     Args:
         params: SearchParams with date range (fechaDesde required, fechaHasta defaults to today)
-        max_workers: Number of threads for parallel detail fetching (default: 10)
+        max_workers: Number of threads for parallel detail fetching (default: 2, max useful with 50 req/min limit)
 
     Returns:
         List of paths to generated Parquet files
@@ -298,7 +315,7 @@ def scrape_historico(params: SearchParams, max_workers: int = 10) -> list[Path]:
     ano_fin = int(params.fechaHasta[-4:])
 
     _ensure_output_dir()
-    rate_limiter = RateLimiter(max_requests=49, time_window=60)
+    rate_limiter = RateLimiter(max_requests=40, time_window=60)  # Conservative limit to avoid 429s
 
     print(f"\n{'='*60}", flush=True)
     print(f"SUBVENCIONES HISTÓRICAS (BDNS)", flush=True)
@@ -337,7 +354,7 @@ def scrape_historico(params: SearchParams, max_workers: int = 10) -> list[Path]:
                 if page == 0:
                     total_elements = data.get("totalElements", 0)
                     pbar.total = data.get("totalPages", 0)
-                    pbar.set_description(f"Páginas (total: {total_elements:,} convocatorias)")
+                    pbar.set_description(f"{total_elements:,} convocatorias encontradas")
 
                 if not content:
                     break
@@ -461,7 +478,7 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
     total_new = 0
     total_duplicates = 0
     total_filtered = 0
-    rate_limiter = RateLimiter(max_requests=49, time_window=60)
+    rate_limiter = RateLimiter(max_requests=40, time_window=60)  # Conservative limit to avoid 429s
     subvencion_pattern = re.compile(r"subvenci[oó]n", re.IGNORECASE)
 
     print(f"\nActualizando subvenciones diarias...\n", flush=True)

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -585,6 +585,13 @@ def scrape_historico(params: SearchParams) -> list[Path]:
             "documentos",
             "anuncios",
         ]
+        
+        # Array columns that need serialization for parquet
+        array_cols = [
+            "tipos_beneficiarios",
+            "sectores",
+            "regiones",
+        ]
 
         def save_batch(records, batch_number):
             """Save current batch to parquet and clear buffer."""
@@ -595,6 +602,11 @@ def scrape_historico(params: SearchParams) -> list[Path]:
 
             # Serialize JSONB columns
             for col in jsonb_cols:
+                if col in df.columns:
+                    df[col] = df[col].apply(lambda x: json.dumps(x) if x is not None else None)
+            
+            # Serialize array columns to JSON strings for parquet compatibility
+            for col in array_cols:
                 if col in df.columns:
                     df[col] = df[col].apply(lambda x: json.dumps(x) if x is not None else None)
 

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -479,6 +479,7 @@ def fetch_convocatoria_detalle(
                 "descripcion_finalidad": data.get("descripcionFinalidad"),
                 "descripcion_bases_reguladoras": data.get("descripcionBasesReguladoras"),
                 "url_bases_reguladoras": data.get("urlBasesReguladoras"),
+                "resumen_bases_reguladoras": None,
                 "se_publica_diario_oficial": data.get("sePublicaDiarioOficial"),
                 "abierto": data.get("abierto"),
                 "fecha_inicio_solicitud": data.get("fechaInicioSolicitud"),
@@ -898,6 +899,7 @@ def scrape_diario(params: SearchParams) -> dict[str, int]:
                     record.get("descripcion_finalidad"),
                     record.get("descripcion_bases_reguladoras"),
                     record.get("url_bases_reguladoras"),
+                    record.get("resumen_bases_reguladoras"),
                     record.get("se_publica_diario_oficial"),
                     record.get("abierto"),
                     record.get("fecha_inicio_solicitud"),
@@ -918,10 +920,10 @@ def scrape_diario(params: SearchParams) -> dict[str, int]:
             (id, nivel1, nivel2, nivel3, sede_electronica, fecha_recepcion,
              instrumento_id, tipo_convocatoria, presupuesto_total, mrr, descripcion, descripcion_leng,
              tipos_beneficiarios, sectores, regiones, descripcion_finalidad, descripcion_bases_reguladoras,
-             url_bases_reguladoras, se_publica_diario_oficial, abierto, fecha_inicio_solicitud,
+             url_bases_reguladoras, resumen_bases_reguladoras, se_publica_diario_oficial, abierto, fecha_inicio_solicitud,
              fecha_fin_solicitud, ayuda_estado, url_ayuda_estado,
              fondos, reglamento, objetivos, sectores_productos, documentos, anuncios)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (id) DO NOTHING
         """
 

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -29,7 +29,6 @@ from etl.config import get_database_url
 # No API_KEY required - public access
 API_BASE_URL = "https://www.infosubvenciones.es/bdnstrans/api/convocatorias"
 API_ENDPOINT_SEARCH = API_BASE_URL + "/busqueda"
-API_ENDPOINT_LATEST = API_BASE_URL + "/ultimas"
 API_ENDPOINT_DETAIL = API_BASE_URL
 
 # Default VPD parameter for detail endpoint
@@ -60,8 +59,14 @@ class SearchParams:
     page: int = 0
     pageSize: int = 10000
     fechaDesde: str | None = None  # Format: "DD/MM/YYYY"
-    fechaHasta: str = datetime.now().strftime("%d/%m/%Y")  # Format: "DD/MM/YYYY"
+    fechaHasta: str | None = None  # Format: "DD/MM/YYYY", defaults to today if None
+    direccion: str = "asc"  # Sort direction: "asc" or "desc"
     vpd: str = field(default=DEFAULT_VPD, init=False)
+
+    def __post_init__(self):
+        """Set default fechaHasta to current date if not provided."""
+        if self.fechaHasta is None:
+            self.fechaHasta = datetime.now().strftime("%d/%m/%Y")
 
     def to_dict(self) -> dict:
         """Convert to dictionary removing None values."""
@@ -94,29 +99,6 @@ class SearchParams:
             datetime.strptime(date_str, "%d/%m/%Y")
         except ValueError:
             raise ValueError(f"{field_name} debe tener formato DD/MM/YYYY, recibido: {date_str}")
-
-
-@dataclass
-class LatestParams:
-    """Parameters for latest grants endpoint (ultimas). pageSize and order are fixed."""
-
-    page: int = 0
-    pageSize: int = 100
-    order: str = field(default="numeroConvocatoria", init=False)
-    direccion: str = field(default="desc", init=False)
-    vpd: str = field(default=DEFAULT_VPD, init=False)
-
-    def to_dict(self) -> dict:
-        """Convert to dictionary."""
-        return asdict(self)
-
-    def validate(self) -> None:
-        """Validate parameters."""
-        if self.page < 0:
-            raise ValueError(f"page debe ser >= 0, recibido: {self.page}")
-
-        if self.pageSize < 100 or self.pageSize > 1000:
-            raise ValueError(f"pageSize debe estar entre [100, 1000]: {self.pageSize}")
 
 
 def _flatten_organo(
@@ -319,15 +301,10 @@ def scrape_historico(params: SearchParams) -> list[Path]:
                 break
 
             for item in content:
-                # Convert numeroConvocatoria to int for consistent type handling
+                # Convert numeroConvocatoria to int as id
                 numero_conv = item.get("numeroConvocatoria")
                 if numero_conv:
-                    light_convocatorias.append(
-                        {
-                            "id": item.get("id"),
-                            "numero_convocatoria": int(numero_conv),
-                        }
-                    )
+                    light_convocatorias.append({"id": int(numero_conv)})
 
             page += 1
 
@@ -380,8 +357,8 @@ def scrape_historico(params: SearchParams) -> list[Path]:
             nonlocal failed_count
             for conv in tqdm(light_convocatorias, unit="conv"):
                 try:
-                    # Convert back to string for API request
-                    result = fetch_convocatoria_detalle(str(conv["numero_convocatoria"]))
+                    # Convert id to string for API request
+                    result = fetch_convocatoria_detalle(str(numero_conv))
                     if result:
                         buffer.put(result)
                     else:
@@ -453,16 +430,16 @@ def scrape_historico(params: SearchParams) -> list[Path]:
         raise
 
 
-def scrape_diario(params: LatestParams) -> dict[str, int]:
+def scrape_diario(params: SearchParams) -> dict[str, int]:
     """
     Scrape latest/daily grants and insert directly into database.
     This is for daily scheduler updates - small volume so direct insert is efficient.
 
-    Fetches detailed information for each convocatoria sequentially (no ThreadPool needed
-    for small volumes).
+    Uses the same search endpoint as scrape_historico but without date filters,
+    fetching the most recent records until duplicates are found.
 
     Args:
-        params: LatestParams for latest updates
+        params: SearchParams for search (fechaDesde should be None for daily updates)
 
     Returns:
         Dictionary with metrics: inserted, omitted, filtered, pages
@@ -483,10 +460,31 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
     subvencion_pattern = re.compile(r"subvenci[oó]n", re.IGNORECASE)
 
     _log("INFO", "Obteniendo convocatorias nuevas...")
-
     try:
         conn = psycopg2.connect(db_url)
         cur = conn.cursor()
+
+        # Get the most recent fecha_recepcion from DB to use as fechaDesde
+        cur.execute(
+            "SELECT MAX(fecha_recepcion) FROM l0.nacional_subvenciones WHERE fecha_recepcion IS NOT NULL"
+        )
+        result = cur.fetchone()
+        max_fecha = result[0] if result and result[0] else None
+
+        if max_fecha:
+            # Set fechaDesde to the most recent date in DB
+            params.fechaDesde = max_fecha.strftime("%d/%m/%Y")
+            _log("INFO", f"Buscando desde fecha más reciente en BD: {params.fechaDesde}")
+        else:
+            # If no records in DB, don't set fechaDesde (get all records)
+            params.fechaDesde = None
+            _log("INFO", "No hay registros en BD, obteniendo todas las convocatorias")
+
+        # Set fechaHasta to current date
+        params.fechaHasta = datetime.now().strftime("%d/%m/%Y")
+
+        # Set direccion to desc to get most recent first
+        params.direccion = "desc"
 
         all_new_convocatorias = []
         page = params.page
@@ -496,7 +494,7 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
         while not is_last_page and not found_duplicates:
             params.page = page
 
-            res = requests.get(API_ENDPOINT_LATEST, params=params.to_dict())
+            res = requests.get(API_ENDPOINT_SEARCH, params=params.to_dict())
 
             if res.status_code != 200:
                 try:
@@ -528,12 +526,7 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
                     continue
                 numero_conv = item.get("numeroConvocatoria")
                 if numero_conv:
-                    light_convocatorias.append(
-                        {
-                            "id": item.get("id"),
-                            "numero_convocatoria": int(numero_conv),
-                        }
-                    )
+                    light_convocatorias.append({"id": int(numero_conv)})
             total_filtered += page_filtered
 
             if not light_convocatorias:
@@ -543,14 +536,12 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
             # Check for duplicates
             cur.execute(
                 "SELECT id FROM l0.nacional_subvenciones WHERE id = ANY(%s)",
-                ([conv["numero_convocatoria"] for conv in light_convocatorias],),
+                ([conv["id"] for conv in light_convocatorias],),
             )
             existing_ids = {row[0] for row in cur.fetchall()}
 
             new_convocatorias = [
-                conv
-                for conv in light_convocatorias
-                if conv["numero_convocatoria"] not in existing_ids
+                conv for conv in light_convocatorias if conv["id"] not in existing_ids
             ]
             total_duplicates += len(existing_ids)
 
@@ -582,7 +573,7 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
         detailed_records = []
         _log("INFO", "Obteniendo detalles de las nuevas convocatorias encontradas...")
         for conv in tqdm(all_new_convocatorias, unit="conv"):
-            detail = fetch_convocatoria_detalle(str(conv["numero_convocatoria"]))
+            detail = fetch_convocatoria_detalle(str(conv["id"]))
             if detail:
                 detailed_records.append(detail)
 
@@ -736,6 +727,7 @@ def main():
             pageSize=10000,
             fechaDesde=fecha_desde,
             fechaHasta=fecha_hasta,
+            direccion="asc",  # For historical scraping, use ascending order
         )
 
         parquet_paths = scrape_historico(params)

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -103,6 +103,7 @@ class LatestParams:
     page: int = 0
     pageSize: int = 100
     order: str = field(default="numeroConvocatoria", init=False)
+    direccion: str = field(default="desc", init=False)
     vpd: str = field(default=DEFAULT_VPD, init=False)
 
     def to_dict(self) -> dict:

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -10,8 +10,6 @@ import pandas as pd
 import os
 import argparse
 import re
-import threading
-from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
 from tqdm import tqdm
 
@@ -50,10 +48,7 @@ def _ensure_output_dir():
 
 
 class RateLimiter:
-    """Manage API rate limiting to avoid exceeding request limits and get API ban.
-
-    Thread-safe implementation using threading.Lock for atomic operations.
-    """
+    """Manage API rate limiting to avoid exceeding request limits and get API ban."""
 
     def __init__(self, max_requests: int = 49, time_window: int = 60):
         """
@@ -66,39 +61,34 @@ class RateLimiter:
         self.max_requests = max_requests
         self.time_window = time_window
         self.request_times = []
-        self._lock = threading.Lock()
 
     def wait_if_needed(self):
-        """Wait if necessary to avoid exceeding rate limit. Thread-safe."""
-        with self._lock:  # Atomic operation
-            now = time.time()
+        """Wait if necessary to avoid exceeding rate limit."""
+        now = time.time()
 
-            # Remove requests outside the current time window
-            self.request_times = [t for t in self.request_times if now - t < self.time_window]
+        # Remove requests outside the current time window
+        self.request_times = [t for t in self.request_times if now - t < self.time_window]
 
-            # Check if we've reached the limit
-            if len(self.request_times) >= self.max_requests:
-                # Calculate how long to wait
-                oldest_request = self.request_times[0]
-                wait_time = self.time_window - (now - oldest_request)
+        # Check if we've reached the limit
+        if len(self.request_times) >= self.max_requests:
+            # Calculate how long to wait
+            oldest_request = self.request_times[0]
+            wait_time = self.time_window - (now - oldest_request)
 
-                if wait_time > 0:
-                    _log(
-                        "WARN",
-                        f"Límite de peticiones alcanzado. Esperando {wait_time:.1f}s...",
-                    )
-                    time.sleep(wait_time + 0.1)
-                    now = time.time()
-                    self.request_times = [
-                        t for t in self.request_times if now - t < self.time_window
-                    ]
+            if wait_time > 0:
+                _log(
+                    "WARN",
+                    f"Límite de peticiones alcanzado. Esperando {wait_time:.1f}s...",
+                )
+                time.sleep(wait_time + 0.1)
+                now = time.time()
+                self.request_times = [t for t in self.request_times if now - t < self.time_window]
 
-            self.request_times.append(time.time())
+        self.request_times.append(time.time())
 
     def reset(self):
-        """Reset the rate limiter. Thread-safe."""
-        with self._lock:
-            self.request_times = []
+        """Reset the rate limiter."""
+        self.request_times = []
 
 
 @dataclass
@@ -192,117 +182,98 @@ def _convert_to_json_serializable(obj):
 def fetch_convocatoria_detalle(
     numero_convocatoria: str,
     rate_limiter: RateLimiter,
-    max_retries: int = 5,
 ) -> dict | None:
     """
     Fetch detailed information for a single convocatoria.
 
-    Implements retry with exponential backoff for 429 errors (rate limit exceeded).
-
     Args:
         numero_convocatoria: The convocatoria number to fetch details for
-        rate_limiter: RateLimiter instance (thread-safe)
-        max_retries: Maximum number of retries for 429 errors (default: 5)
+        rate_limiter: RateLimiter instance
 
     Returns:
-        Dictionary with detailed convocatoria data or None if error after all retries
+        Dictionary with detailed convocatoria data or None if error
     """
     params = {
         "vpd": DEFAULT_VPD,
         "numConv": numero_convocatoria,
     }
 
-    for attempt in range(max_retries + 1):
-        try:
-            rate_limiter.wait_if_needed()
-            res = requests.get(API_ENDPOINT_DETAIL, params=params, timeout=30)
+    try:
+        rate_limiter.wait_if_needed()
+        res = requests.get(API_ENDPOINT_DETAIL, params=params, timeout=30)
 
-            if res.status_code == 429:
-                # Rate limit exceeded - retry with exponential backoff
-                if attempt < max_retries:
-                    wait_time = (2**attempt) * 0.5  # 0.5s, 1s, 2s, 4s, 8s
-                    time.sleep(wait_time)
-                    continue
-                else:
-                    _log("WARN", f"Max retries alcanzado para {numero_convocatoria} (429)")
-                    return None
-
-            if res.status_code != 200:
-                _log(
-                    "WARN",
-                    f"Error al obtener detalle de convocatoria {numero_convocatoria}: HTTP {res.status_code}",
-                )
-                return None
-
-            data = res.json()
-
-            # Flatten organo
-            organo = data.get("organo", {})
-            nivel1, nivel2, nivel3 = _flatten_organo(organo)
-
-            # Build flattened record
-            record = {
-                "id": data.get("id"),
-                "nivel1": nivel1,
-                "nivel2": nivel2,
-                "nivel3": nivel3,
-                "sede_electronica": data.get("sedeElectronica"),
-                "codigo_bdns": data.get("codigoBDNS"),
-                "fecha_recepcion": data.get("fechaRecepcion"),
-                "instrumentos": _convert_to_json_serializable(data.get("instrumentos")),
-                "tipo_convocatoria": data.get("tipoConvocatoria"),
-                "presupuesto_total": data.get("presupuestoTotal"),
-                "mrr": data.get("mrr"),
-                "descripcion": data.get("descripcion"),
-                "descripcion_leng": data.get("descripcionLeng"),
-                "tipos_beneficiarios": _convert_to_json_serializable(
-                    data.get("tiposBeneficiarios")
-                ),
-                "sectores": _convert_to_json_serializable(data.get("sectores")),
-                "regiones": _convert_to_json_serializable(data.get("regiones")),
-                "descripcion_finalidad": data.get("descripcionFinalidad"),
-                "descripcion_bases_reguladoras": data.get("descripcionBasesReguladoras"),
-                "url_bases_reguladoras": data.get("urlBasesReguladoras"),
-                "se_publica_diario_oficial": data.get("sePublicaDiarioOficial"),
-                "abierto": data.get("abierto"),
-                "fecha_inicio_solicitud": data.get("fechaInicioSolicitud"),
-                "fecha_fin_solicitud": data.get("fechaFinSolicitud"),
-                "text_inicio": data.get("textInicio"),
-                "text_fin": data.get("textFin"),
-                "ayuda_estado": data.get("ayudaEstado"),
-                "url_ayuda_estado": data.get("urlAyudaEstado"),
-                "fondos": _convert_to_json_serializable(data.get("fondos")),
-                "reglamento": _convert_to_json_serializable(data.get("reglamento")),
-                "objetivos": _convert_to_json_serializable(data.get("objetivos")),
-                "sectores_productos": _convert_to_json_serializable(data.get("sectoresProductos")),
-                "documentos": _convert_to_json_serializable(data.get("documentos")),
-                "anuncios": _convert_to_json_serializable(data.get("anuncios")),
-                "advertencia": data.get("advertencia"),
-            }
-
-            return record
-
-        except Exception as e:
+        if res.status_code != 200:
             _log(
-                "ERROR",
-                f"Excepción al obtener detalle de convocatoria {numero_convocatoria}: {e}",
+                "WARN",
+                f"Error al obtener detalle de convocatoria {numero_convocatoria}: HTTP {res.status_code}",
             )
             return None
 
-    return None
+        data = res.json()
+
+        # Flatten organo
+        organo = data.get("organo", {})
+        nivel1, nivel2, nivel3 = _flatten_organo(organo)
+
+        # Build flattened record
+        record = {
+            "id": data.get("id"),
+            "nivel1": nivel1,
+            "nivel2": nivel2,
+            "nivel3": nivel3,
+            "sede_electronica": data.get("sedeElectronica"),
+            "codigo_bdns": data.get("codigoBDNS"),
+            "fecha_recepcion": data.get("fechaRecepcion"),
+            "instrumentos": _convert_to_json_serializable(data.get("instrumentos")),
+            "tipo_convocatoria": data.get("tipoConvocatoria"),
+            "presupuesto_total": data.get("presupuestoTotal"),
+            "mrr": data.get("mrr"),
+            "descripcion": data.get("descripcion"),
+            "descripcion_leng": data.get("descripcionLeng"),
+            "tipos_beneficiarios": _convert_to_json_serializable(data.get("tiposBeneficiarios")),
+            "sectores": _convert_to_json_serializable(data.get("sectores")),
+            "regiones": _convert_to_json_serializable(data.get("regiones")),
+            "descripcion_finalidad": data.get("descripcionFinalidad"),
+            "descripcion_bases_reguladoras": data.get("descripcionBasesReguladoras"),
+            "url_bases_reguladoras": data.get("urlBasesReguladoras"),
+            "se_publica_diario_oficial": data.get("sePublicaDiarioOficial"),
+            "abierto": data.get("abierto"),
+            "fecha_inicio_solicitud": data.get("fechaInicioSolicitud"),
+            "fecha_fin_solicitud": data.get("fechaFinSolicitud"),
+            "text_inicio": data.get("textInicio"),
+            "text_fin": data.get("textFin"),
+            "ayuda_estado": data.get("ayudaEstado"),
+            "url_ayuda_estado": data.get("urlAyudaEstado"),
+            "fondos": _convert_to_json_serializable(data.get("fondos")),
+            "reglamento": _convert_to_json_serializable(data.get("reglamento")),
+            "objetivos": _convert_to_json_serializable(data.get("objetivos")),
+            "sectores_productos": _convert_to_json_serializable(data.get("sectoresProductos")),
+            "documentos": _convert_to_json_serializable(data.get("documentos")),
+            "anuncios": _convert_to_json_serializable(data.get("anuncios")),
+            "advertencia": data.get("advertencia"),
+        }
+
+        return record
+
+    except Exception as e:
+        _log(
+            "ERROR",
+            f"Excepción al obtener detalle de convocatoria {numero_convocatoria}: {e}",
+        )
+        return None
 
 
-def scrape_historico(params: SearchParams, max_workers: int = 2) -> list[Path]:
+def scrape_historico(params: SearchParams) -> list[Path]:
     """
     Scrape historical grants data and save to Parquet files.
     This is for initial bulk load - generates Parquet files for etl/ingest_l0.py to process.
 
-    Uses ThreadPool to fetch detailed information for each convocatoria in parallel.
+    Fetches detailed information for each convocatoria sequentially (no parallelism needed
+    due to strict API rate limiting of 50 req/min).
     Generates multiple parquet files with max 20000 records each.
 
     Args:
         params: SearchParams with date range (fechaDesde required, fechaHasta defaults to today)
-        max_workers: Number of threads for parallel detail fetching (default: 2, max useful with 50 req/min limit)
 
     Returns:
         List of paths to generated Parquet files
@@ -311,8 +282,6 @@ def scrape_historico(params: SearchParams, max_workers: int = 2) -> list[Path]:
         raise ValueError("fechaDesde es requerido para scrape historico")
 
     params.validate()
-    ano_inicio = int(params.fechaDesde[-4:])
-    ano_fin = int(params.fechaHasta[-4:])
 
     _ensure_output_dir()
     rate_limiter = RateLimiter(max_requests=40, time_window=60)  # Conservative limit to avoid 429s
@@ -352,9 +321,7 @@ def scrape_historico(params: SearchParams, max_workers: int = 2) -> list[Path]:
                 is_last_page = data.get("last", True)
 
                 if page == 0:
-                    total_elements = data.get("totalElements", 0)
                     pbar.total = data.get("totalPages", 0)
-                    pbar.set_description(f"{total_elements:,} convocatorias encontradas")
 
                 if not content:
                     break
@@ -372,32 +339,20 @@ def scrape_historico(params: SearchParams, max_workers: int = 2) -> list[Path]:
 
         print(f"INFO {len(light_convocatorias):,} convocatorias obtenidas\n", flush=True)
 
-        print(f"Obteniendo detalles de convocatorias ({max_workers} workers)...", flush=True)
+        print("Obteniendo detalles de convocatorias...", flush=True)
         detailed_records = []
         failed_count = 0
 
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = [
-                executor.submit(
-                    fetch_convocatoria_detalle,
-                    conv["numero_convocatoria"],
-                    rate_limiter,
-                )
-                for conv in light_convocatorias
-            ]
-
-            with tqdm(total=len(light_convocatorias), desc="Detalles", unit="conv") as pbar:
-                for future in as_completed(futures):
-                    try:
-                        result = future.result()
-                        if result:
-                            detailed_records.append(result)
-                        else:
-                            failed_count += 1
-                    except Exception as e:
-                        _log("ERROR", f"Excepción: {e}")
-                        failed_count += 1
-                    pbar.update(1)
+        for conv in tqdm(light_convocatorias, desc="Detalles", unit="conv"):
+            try:
+                result = fetch_convocatoria_detalle(conv["numero_convocatoria"], rate_limiter)
+                if result:
+                    detailed_records.append(result)
+                else:
+                    failed_count += 1
+            except Exception as e:
+                _log("ERROR", f"Excepción: {e}")
+                failed_count += 1
 
         if failed_count > 0:
             print(f"{failed_count} convocatorias fallaron", flush=True)

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -523,10 +523,8 @@ def scrape_historico(params: SearchParams) -> list[Path]:
 
     _ensure_output_dir()
 
-    _log("INFO", "=" * 60)
     _log("INFO", "SUBVENCIONES HISTÓRICAS (BDNS)")
     _log("INFO", f"Rango: {params.fechaDesde} — {params.fechaHasta}")
-    _log("INFO", "=" * 60)
 
     try:
         light_convocatorias = []

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -12,8 +12,8 @@ import argparse
 import re
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Optional
 import json
+from tqdm import tqdm
 
 LOG_PREFIX = "[subvenciones]"
 
@@ -30,9 +30,7 @@ from etl.config import get_database_url
 API_BASE_URL = "https://www.infosubvenciones.es/bdnstrans/api/convocatorias"
 API_ENDPOINT_SEARCH = API_BASE_URL + "/busqueda"
 API_ENDPOINT_LATEST = API_BASE_URL + "/ultimas"
-API_ENDPOINT_DETAIL = (
-    API_BASE_URL  # Same as base URL, uses query params vpd and numConv
-)
+API_ENDPOINT_DETAIL = API_BASE_URL
 
 # Default VPD parameter for detail endpoint
 DEFAULT_VPD = "GE"
@@ -68,7 +66,7 @@ class RateLimiter:
         self.max_requests = max_requests
         self.time_window = time_window
         self.request_times = []
-        self._lock = threading.Lock()  # Thread-safe lock
+        self._lock = threading.Lock()
 
     def wait_if_needed(self):
         """Wait if necessary to avoid exceeding rate limit. Thread-safe."""
@@ -76,9 +74,7 @@ class RateLimiter:
             now = time.time()
 
             # Remove requests outside the current time window
-            self.request_times = [
-                t for t in self.request_times if now - t < self.time_window
-            ]
+            self.request_times = [t for t in self.request_times if now - t < self.time_window]
 
             # Check if we've reached the limit
             if len(self.request_times) >= self.max_requests:
@@ -113,6 +109,7 @@ class SearchParams:
     pageSize: int = 10000
     fechaDesde: str | None = None  # Format: "DD/MM/YYYY"
     fechaHasta: str = datetime.now().strftime("%d/%m/%Y")  # Format: "DD/MM/YYYY"
+    vpd: str = field(default=DEFAULT_VPD, init=False)
 
     def to_dict(self) -> dict:
         """Convert to dictionary removing None values."""
@@ -123,9 +120,7 @@ class SearchParams:
         if self.page < 0:
             raise ValueError(f"page debe ser >= 0, recibido: {self.page}")
         if self.pageSize < 50 or self.pageSize > 10000:
-            raise ValueError(
-                f"pageSize debe estar entre 50-10000, recibido: {self.pageSize}"
-            )
+            raise ValueError(f"pageSize debe estar entre 50-10000, recibido: {self.pageSize}")
 
         # Validate date formats if present
         if self.fechaDesde:
@@ -146,9 +141,7 @@ class SearchParams:
         try:
             datetime.strptime(date_str, "%d/%m/%Y")
         except ValueError:
-            raise ValueError(
-                f"{field_name} debe tener formato DD/MM/YYYY, recibido: {date_str}"
-            )
+            raise ValueError(f"{field_name} debe tener formato DD/MM/YYYY, recibido: {date_str}")
 
 
 @dataclass
@@ -158,6 +151,7 @@ class LatestParams:
     page: int = 0
     pageSize: int = 100
     order: str = field(default="numeroConvocatoria", init=False)
+    vpd: str = field(default=DEFAULT_VPD, init=False)
 
     def to_dict(self) -> dict:
         """Convert to dictionary."""
@@ -173,8 +167,8 @@ class LatestParams:
 
 
 def _flatten_organo(
-    organo: Optional[dict],
-) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    organo: dict | None,
+) -> tuple[str | None, str | None, str | None]:
     """Flatten organo nested object to nivel1, nivel2, nivel3."""
     if not organo:
         return None, None, None
@@ -198,8 +192,7 @@ def _convert_to_json_serializable(obj):
 def fetch_convocatoria_detalle(
     numero_convocatoria: str,
     rate_limiter: RateLimiter,
-    vpd: str = DEFAULT_VPD,
-) -> Optional[dict]:
+) -> dict | None:
     """
     Fetch detailed information for a single convocatoria.
 
@@ -215,7 +208,7 @@ def fetch_convocatoria_detalle(
         rate_limiter.wait_if_needed()
 
         params = {
-            "vpd": vpd,
+            "vpd": DEFAULT_VPD,
             "numConv": numero_convocatoria,
         }
 
@@ -249,9 +242,7 @@ def fetch_convocatoria_detalle(
             "mrr": data.get("mrr"),
             "descripcion": data.get("descripcion"),
             "descripcion_leng": data.get("descripcionLeng"),
-            "tipos_beneficiarios": _convert_to_json_serializable(
-                data.get("tiposBeneficiarios")
-            ),
+            "tipos_beneficiarios": _convert_to_json_serializable(data.get("tiposBeneficiarios")),
             "sectores": _convert_to_json_serializable(data.get("sectores")),
             "regiones": _convert_to_json_serializable(data.get("regiones")),
             "descripcion_finalidad": data.get("descripcionFinalidad"),
@@ -268,9 +259,7 @@ def fetch_convocatoria_detalle(
             "fondos": _convert_to_json_serializable(data.get("fondos")),
             "reglamento": _convert_to_json_serializable(data.get("reglamento")),
             "objetivos": _convert_to_json_serializable(data.get("objetivos")),
-            "sectores_productos": _convert_to_json_serializable(
-                data.get("sectoresProductos")
-            ),
+            "sectores_productos": _convert_to_json_serializable(data.get("sectoresProductos")),
             "documentos": _convert_to_json_serializable(data.get("documentos")),
             "anuncios": _convert_to_json_serializable(data.get("anuncios")),
             "advertencia": data.get("advertencia"),
@@ -309,149 +298,107 @@ def scrape_historico(params: SearchParams, max_workers: int = 10) -> list[Path]:
     ano_fin = int(params.fechaHasta[-4:])
 
     _ensure_output_dir()
-
-    # Step 1: Fetch all light convocatorias
-    light_convocatorias = []
     rate_limiter = RateLimiter(max_requests=49, time_window=60)
-
-    page = params.page
-    is_last_page = False
-    total_elements = 0
 
     print(f"\n{'='*60}", flush=True)
     print(f"SUBVENCIONES HISTÓRICAS (BDNS)", flush=True)
     print(f"   Rango: {params.fechaDesde} — {params.fechaHasta}", flush=True)
-    print(f"   Endpoint: {API_ENDPOINT_SEARCH}", flush=True)
-    print(f"{'='*60}", flush=True)
+    print(f"{'='*60}\n", flush=True)
 
     try:
-        # Fase 1: Obtener convocatorias ligeras
-        _log("INFO", "Fase 1: Obteniendo convocatorias ligeras...")
-        while not is_last_page:
-            params.page = page
+        light_convocatorias = []
+        page = 0
+        is_last_page = False
 
-            rate_limiter.wait_if_needed()
-            res = requests.get(API_ENDPOINT_SEARCH, params=params.to_dict())
+        print("Obteniendo lista de convocatorias...", flush=True)
+        with tqdm(desc="Páginas", unit="pag") as pbar:
+            while not is_last_page:
+                params.page = page
+                rate_limiter.wait_if_needed()
+                res = requests.get(API_ENDPOINT_SEARCH, params=params.to_dict())
 
-            if res.status_code != 200:
-                try:
-                    error_data = res.json()
-                    if "errores" in error_data:
-                        error_msgs = "\n  - ".join(error_data["errores"])
-                        raise ValueError(
-                            f"Error de la API ({error_data.get('codigo', 'UNKNOWN')}):\n  - {error_msgs}"
-                        )
-                except ValueError:
-                    raise
-                except Exception:
-                    res.raise_for_status()
+                if res.status_code != 200:
+                    try:
+                        error_data = res.json()
+                        if "errores" in error_data:
+                            error_msgs = "\n  - ".join(error_data["errores"])
+                            raise ValueError(
+                                f"Error de la API ({error_data.get('codigo', 'UNKNOWN')}):\n  {error_msgs}"
+                            )
+                    except ValueError:
+                        raise
+                    except Exception:
+                        res.raise_for_status()
 
-            data = res.json()
+                data = res.json()
+                content = data.get("content", [])
+                is_last_page = data.get("last", True)
 
-            content = data.get("content", [])
-            is_last_page = data.get("last", True)
-            total_pages = data.get("totalPages", "?")
+                if page == 0:
+                    total_elements = data.get("totalElements", 0)
+                    pbar.total = data.get("totalPages", 0)
+                    pbar.set_description(f"Páginas (total: {total_elements:,} convocatorias)")
 
-            if page == 0:
-                total_elements = data.get("totalElements", 0)
-                _log(
-                    "INFO",
-                    f"Total registros en API: {total_elements:,} ({total_pages} páginas)",
-                )
+                if not content:
+                    break
 
-            if not content:
-                _log("WARN", f"Página {page + 1} vacía — fin de datos")
-                break
+                for item in content:
+                    light_convocatorias.append(
+                        {
+                            "id": item.get("id"),
+                            "numero_convocatoria": item.get("numeroConvocatoria"),
+                        }
+                    )
 
-            for item in content:
-                light_convocatorias.append(
-                    {
-                        "id": item.get("id"),
-                        "numero_convocatoria": item.get("numeroConvocatoria"),
-                    }
-                )
+                page += 1
+                pbar.update(1)
 
-            pct = (
-                (len(light_convocatorias) / total_elements * 100)
-                if total_elements
-                else 0
-            )
-            _log(
-                "INFO",
-                f"Página {page + 1}/{total_pages} — {len(light_convocatorias):,}/{total_elements:,} convocatorias ({pct:.0f}%)",
-            )
+        print(f"INFO {len(light_convocatorias):,} convocatorias obtenidas\n", flush=True)
 
-            page += 1
-
-        _log(
-            "INFO",
-            f"Fase 1 completada: {len(light_convocatorias):,} convocatorias obtenidas",
-        )
-
-        # Fase 2: Obtener detalles en paralelo usando ThreadPool
-        _log(
-            "INFO",
-            f"Fase 2: Obteniendo detalles (ThreadPool con {max_workers} workers)...",
-        )
+        print(f"Obteniendo detalles de convocatorias ({max_workers} workers)...", flush=True)
         detailed_records = []
         failed_count = 0
 
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            # Submit all tasks
-            future_to_conv = {
+            futures = [
                 executor.submit(
                     fetch_convocatoria_detalle,
                     conv["numero_convocatoria"],
                     rate_limiter,
-                ): conv
+                )
                 for conv in light_convocatorias
-            }
+            ]
 
-            # Process completed tasks
-            for i, future in enumerate(as_completed(future_to_conv), 1):
-                try:
-                    result = future.result()
-                    if result:
-                        detailed_records.append(result)
-                    else:
+            with tqdm(total=len(light_convocatorias), desc="Detalles", unit="conv") as pbar:
+                for future in as_completed(futures):
+                    try:
+                        result = future.result()
+                        if result:
+                            detailed_records.append(result)
+                        else:
+                            failed_count += 1
+                    except Exception as e:
+                        _log("ERROR", f"Excepción: {e}")
                         failed_count += 1
-                except Exception as e:
-                    _log("ERROR", f"Excepción en thread: {e}")
-                    failed_count += 1
-
-                # Progress update every 100 records
-                if i % 100 == 0 or i == len(light_convocatorias):
-                    pct = i / len(light_convocatorias) * 100
-                    _log(
-                        "INFO",
-                        f"Progreso: {i:,}/{len(light_convocatorias):,} ({pct:.1f}%) — Exitosos: {len(detailed_records):,}, Fallidos: {failed_count}",
-                    )
-
-        _log(
-            "INFO",
-            f"Fase 2 completada: {len(detailed_records):,} registros detallados obtenidos",
-        )
+                    pbar.update(1)
 
         if failed_count > 0:
-            _log("WARN", f"{failed_count} convocatorias fallaron al obtener detalles")
+            print(f"{failed_count} convocatorias fallaron", flush=True)
 
         if not detailed_records:
             raise ValueError("No se obtuvieron registros detallados")
 
-        # Fase 3: Generar parquets en batches de MAX_RECORDS_PER_PARQUET
-        _log(
-            "INFO",
-            f"Fase 3: Generando parquets (máximo {MAX_RECORDS_PER_PARQUET:,} registros por archivo)...",
-        )
+        print(f"INFO {len(detailed_records):,} registros detallados obtenidos\n", flush=True)
+
+        # Fase 3: Generar parquets en batches
+        print(f"Generando parquets (máx {MAX_RECORDS_PER_PARQUET:,} por archivo)...", flush=True)
         parquet_paths = []
 
         for batch_idx in range(0, len(detailed_records), MAX_RECORDS_PER_PARQUET):
-            batch_records = detailed_records[
-                batch_idx : batch_idx + MAX_RECORDS_PER_PARQUET
-            ]
+            batch_records = detailed_records[batch_idx : batch_idx + MAX_RECORDS_PER_PARQUET]
             df = pd.DataFrame(batch_records)
 
-            # Ensure JSONB columns are properly serialized
+            # Serialize JSONB columns
             jsonb_cols = [
                 "instrumentos",
                 "tipos_beneficiarios",
@@ -466,32 +413,25 @@ def scrape_historico(params: SearchParams, max_workers: int = 10) -> list[Path]:
             ]
             for col in jsonb_cols:
                 if col in df.columns:
-                    df[col] = df[col].apply(
-                        lambda x: json.dumps(x) if x is not None else None
-                    )
+                    df[col] = df[col].apply(lambda x: json.dumps(x) if x is not None else None)
 
             batch_num = batch_idx // MAX_RECORDS_PER_PARQUET
-            parquet_filename = f"licitaciones_subvenciones_{ano_inicio}_{ano_fin}_batch{batch_num:03d}.parquet"
+            parquet_filename = f"_part_subvenciones_{batch_num:04d}.parquet"
             parquet_path = OUTPUT_DIR / parquet_filename
 
             df.to_parquet(parquet_path, engine="pyarrow", index=False)
             parquet_paths.append(parquet_path)
 
             size_mb = parquet_path.stat().st_size / (1024 * 1024)
-            _log(
-                "INFO",
-                f"Parquet generado: {parquet_path.name} ({len(df):,} registros, {size_mb:.1f} MB)",
+            print(
+                f"INFO {parquet_path.name} ({len(df):,} registros guardados, {size_mb:.1f} MB)",
+                flush=True,
             )
-
-        print(f"\n✅ SCRAPING COMPLETADO: subvenciones históricas", flush=True)
-        _log("INFO", f"Total archivos parquet: {len(parquet_paths)}")
-        _log("INFO", f"Total registros: {len(detailed_records):,}")
 
         return parquet_paths
 
     except Exception as err:
-        print(f"\n❌ ERROR: scraping histórico falló", flush=True)
-        _log("ERROR", f"{err}")
+        print(f"\nERROR: {err}\n", flush=True)
         raise
 
 
@@ -524,15 +464,10 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
     rate_limiter = RateLimiter(max_requests=49, time_window=60)
     subvencion_pattern = re.compile(r"subvenci[oó]n", re.IGNORECASE)
 
-    print(f"\n{'='*60}", flush=True)
-    print(f"SUBVENCIONES DIARIAS (BDNS)", flush=True)
-    print(f"   Endpoint: {API_ENDPOINT_LATEST}", flush=True)
-    print(f"   Modo: insert directo en BD con detalles completos", flush=True)
-    print(f"{'='*60}", flush=True)
+    print(f"\nActualizando subvenciones diarias...\n", flush=True)
 
     try:
         conn = psycopg2.connect(db_url)
-        _log("INFO", "Conexión a base de datos establecida")
 
         page = params.page
         is_last_page = False
@@ -549,7 +484,7 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
                     if "errores" in error_data:
                         error_msgs = "\n  - ".join(error_data["errores"])
                         raise ValueError(
-                            f"Error de la API ({error_data.get('codigo', 'UNKNOWN')}):\n  - {error_msgs}"
+                            f"Error de la API ({error_data.get('codigo', 'UNKNOWN')}):\n msj error: {error_msgs}"
                         )
                 except ValueError:
                     raise
@@ -560,7 +495,6 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
 
             content = data.get("content", [])
             is_last_page = data.get("last", True)
-            total_pages = data.get("totalPages", "?")
 
             if not content:
                 break
@@ -594,44 +528,26 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
                 existing_ids = {row[0] for row in cur.fetchall()}
 
                 new_convocatorias = [
-                    conv
-                    for conv in light_convocatorias
-                    if conv["id"] not in existing_ids
+                    conv for conv in light_convocatorias if conv["id"] not in existing_ids
                 ]
                 page_dups = len(existing_ids)
                 total_duplicates += page_dups
 
                 if not new_convocatorias:
-                    _log("INFO", f"Página {page + 1}: {page_dups} duplicados, 0 nuevos")
-                    # If we found duplicates, stop searching (assuming chronological order)
+                    # If we found duplicates, stop searching
                     if existing_ids:
                         break
                     page += 1
                     continue
 
                 # Fetch details for new convocatorias (sequential, no ThreadPool)
-                _log(
-                    "INFO",
-                    f"Obteniendo detalles para {len(new_convocatorias)} nuevas convocatorias...",
-                )
                 detailed_records = []
-                for i, conv in enumerate(new_convocatorias, 1):
-                    detail = fetch_convocatoria_detalle(
-                        conv["numero_convocatoria"], rate_limiter
-                    )
+                for conv in tqdm(new_convocatorias, desc="Obteniendo detalles", unit="conv"):
+                    detail = fetch_convocatoria_detalle(conv["numero_convocatoria"], rate_limiter)
                     if detail:
                         detailed_records.append(detail)
-                    else:
-                        _log(
-                            "WARN",
-                            f"No se pudo obtener detalle para {conv['numero_convocatoria']}",
-                        )
-
-                    if i % 10 == 0:
-                        _log("INFO", f"Progreso detalles: {i}/{len(new_convocatorias)}")
 
                 if not detailed_records:
-                    _log("WARN", "No se obtuvieron registros detallados válidos")
                     page += 1
                     continue
 
@@ -706,18 +622,19 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
                         )
                     )
 
-                execute_batch(cur, insert_sql, records_to_insert, page_size=100)
+                execute_batch(cur, insert_sql, records_to_insert)
                 conn.commit()
                 total_new += len(records_to_insert)
-                _log("INFO", f"Insertados {len(records_to_insert)} registros nuevos")
 
-                # If we found duplicates, stop searching
                 if existing_ids:
                     break
 
             page += 1
 
-        print(f"\n✅ SCRAPING COMPLETADO: subvenciones diarias", flush=True)
+        print(
+            f"\nCOMPLETADO: {total_new} nuevos, {total_duplicates} duplicados, {total_filtered} filtrados\n",
+            flush=True,
+        )
 
         return {
             "inserted": total_new,
@@ -727,8 +644,7 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
         }
 
     except Exception as err:
-        print(f"\n❌ ERROR: scraping diario falló", flush=True)
-        _log("ERROR", f"{err}")
+        print(f"\nERROR: {err}\n", flush=True)
         if conn:
             conn.rollback()
         raise

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -377,7 +377,7 @@ def scrape_historico(params: SearchParams) -> list[Path]:
         def fetcher():
             """Thread 1: fetch + preprocesar → buffer."""
             nonlocal failed_count
-            for conv in tqdm(light_convocatorias, unit="conv", desc="Fetch+Preproc"):
+            for conv in tqdm(light_convocatorias, unit="conv"):
                 try:
                     # Convert back to string for API request
                     result = fetch_convocatoria_detalle(str(conv["numero_convocatoria"]))
@@ -574,12 +574,13 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
 
         _log(
             "INFO",
-            f"{len(all_new_convocatorias)} convocatorias nuevas encontradas, guardando en BD...",
+            f"{len(all_new_convocatorias)} convocatorias nuevas encontradas",
         )
 
         # FASE 2: Obtener detalles de todas las convocatorias e insertar
         detailed_records = []
-        for conv in all_new_convocatorias:
+        _log("INFO", "Obteniendo detalles de las nuevas convocatorias encontradas...")
+        for conv in tqdm(all_new_convocatorias, unit="conv"):
             detail = fetch_convocatoria_detalle(str(conv["numero_convocatoria"]))
             if detail:
                 detailed_records.append(detail)
@@ -593,7 +594,7 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
                 "pages": page + 1,
             }
 
-        # Prepare all records for insertion
+        _log("INFO", "Guardando en BD...")
         records_to_insert = []
         jsonb_cols = [
             "instrumentos",

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -465,8 +465,6 @@ def fetch_convocatoria_detalle(
                 "abierto": data.get("abierto"),
                 "fecha_inicio_solicitud": data.get("fechaInicioSolicitud"),
                 "fecha_fin_solicitud": data.get("fechaFinSolicitud"),
-                "text_inicio": data.get("textInicio"),
-                "text_fin": data.get("textFin"),
                 "ayuda_estado": data.get("ayudaEstado"),
                 "url_ayuda_estado": data.get("urlAyudaEstado"),
                 "fondos": _normalize_empty_jsonb(_convert_to_json_serializable(data.get("fondos"))),
@@ -872,8 +870,6 @@ def scrape_diario(params: SearchParams) -> dict[str, int]:
                     record.get("abierto"),
                     record.get("fecha_inicio_solicitud"),
                     record.get("fecha_fin_solicitud"),
-                    record.get("text_inicio"),
-                    record.get("text_fin"),
                     record.get("ayuda_estado"),
                     record.get("url_ayuda_estado"),
                     record.get("fondos"),
@@ -891,9 +887,9 @@ def scrape_diario(params: SearchParams) -> dict[str, int]:
              instrumento_id, tipo_convocatoria, presupuesto_total, mrr, descripcion, descripcion_leng,
              tipos_beneficiarios, sectores, regiones, descripcion_finalidad, descripcion_bases_reguladoras,
              url_bases_reguladoras, se_publica_diario_oficial, abierto, fecha_inicio_solicitud,
-             fecha_fin_solicitud, text_inicio, text_fin, ayuda_estado, url_ayuda_estado,
+             fecha_fin_solicitud, ayuda_estado, url_ayuda_estado,
              fondos, reglamento, objetivos, sectores_productos, documentos, anuncios)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (id) DO NOTHING
         """
 

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -507,7 +507,8 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
 
                 # Fetch details for new convocatorias (sequential, no ThreadPool)
                 detailed_records = []
-                for conv in tqdm(new_convocatorias, desc="Obteniendo detalles", unit="conv"):
+                _log("INFO", "Obteniendo detalles de convocatorias...")
+                for conv in tqdm(new_convocatorias, unit="conv"):
                     detail = fetch_convocatoria_detalle(conv["numero_convocatoria"], rate_limiter)
                     if detail:
                         detailed_records.append(detail)

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -34,7 +34,7 @@ API_ENDPOINT_DETAIL = API_BASE_URL
 DEFAULT_VPD = "GE"
 
 # Maximum records per parquet file
-MAX_RECORDS_PER_PARQUET = 20000
+MAX_RECORDS_PER_PARQUET = 100
 
 # Directory configuration (similar to nacional/licitaciones.py)
 _repo_root = Path(__file__).resolve().parent.parent

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -10,6 +10,10 @@ import pandas as pd
 import os
 import argparse
 import re
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Optional
+import json
 
 LOG_PREFIX = "[subvenciones]"
 
@@ -26,6 +30,15 @@ from etl.config import get_database_url
 API_BASE_URL = "https://www.infosubvenciones.es/bdnstrans/api/convocatorias"
 API_ENDPOINT_SEARCH = API_BASE_URL + "/busqueda"
 API_ENDPOINT_LATEST = API_BASE_URL + "/ultimas"
+API_ENDPOINT_DETAIL = (
+    API_BASE_URL  # Same as base URL, uses query params vpd and numConv
+)
+
+# Default VPD parameter for detail endpoint
+DEFAULT_VPD = "GE"
+
+# Maximum records per parquet file
+MAX_RECORDS_PER_PARQUET = 20000
 
 # Directory configuration (similar to nacional/licitaciones.py)
 _repo_root = Path(__file__).resolve().parent.parent
@@ -39,7 +52,10 @@ def _ensure_output_dir():
 
 
 class RateLimiter:
-    """Manage API rate limiting to avoid exceeding request limits and get API ban."""
+    """Manage API rate limiting to avoid exceeding request limits and get API ban.
+
+    Thread-safe implementation using threading.Lock for atomic operations.
+    """
 
     def __init__(self, max_requests: int = 49, time_window: int = 60):
         """
@@ -52,38 +68,41 @@ class RateLimiter:
         self.max_requests = max_requests
         self.time_window = time_window
         self.request_times = []
+        self._lock = threading.Lock()  # Thread-safe lock
 
     def wait_if_needed(self):
-        """Wait if necessary to avoid exceeding rate limit."""
-        now = time.time()
+        """Wait if necessary to avoid exceeding rate limit. Thread-safe."""
+        with self._lock:  # Atomic operation
+            now = time.time()
 
-        # Remove requests outside the current time window
-        self.request_times = [
-            t for t in self.request_times if now - t < self.time_window
-        ]
+            # Remove requests outside the current time window
+            self.request_times = [
+                t for t in self.request_times if now - t < self.time_window
+            ]
 
-        # Check if we've reached the limit
-        if len(self.request_times) >= self.max_requests:
-            # Calculate how long to wait
-            oldest_request = self.request_times[0]
-            wait_time = self.time_window - (now - oldest_request)
+            # Check if we've reached the limit
+            if len(self.request_times) >= self.max_requests:
+                # Calculate how long to wait
+                oldest_request = self.request_times[0]
+                wait_time = self.time_window - (now - oldest_request)
 
-            if wait_time > 0:
-                _log(
-                    "WARN",
-                    f"Límite de peticiones alcanzado. Esperando {wait_time:.1f}s...",
-                )
-                time.sleep(wait_time + 0.1)
-                now = time.time()
-                self.request_times = [
-                    t for t in self.request_times if now - t < self.time_window
-                ]
+                if wait_time > 0:
+                    _log(
+                        "WARN",
+                        f"Límite de peticiones alcanzado. Esperando {wait_time:.1f}s...",
+                    )
+                    time.sleep(wait_time + 0.1)
+                    now = time.time()
+                    self.request_times = [
+                        t for t in self.request_times if now - t < self.time_window
+                    ]
 
-        self.request_times.append(time.time())
+            self.request_times.append(time.time())
 
     def reset(self):
-        """Reset the rate limiter."""
-        self.request_times = []
+        """Reset the rate limiter. Thread-safe."""
+        with self._lock:
+            self.request_times = []
 
 
 @dataclass
@@ -94,8 +113,6 @@ class SearchParams:
     pageSize: int = 10000
     fechaDesde: str | None = None  # Format: "DD/MM/YYYY"
     fechaHasta: str = datetime.now().strftime("%d/%m/%Y")  # Format: "DD/MM/YYYY"
-    descripcion: str = field(default="Subvención", init=False)
-    descripcionTipoBusqueda: str = field(default=2, init=False)
 
     def to_dict(self) -> dict:
         """Convert to dictionary removing None values."""
@@ -155,16 +172,134 @@ class LatestParams:
             raise ValueError(f"pageSize debe estar entre [100, 1000]: {self.pageSize}")
 
 
-def scrape_historico(params: SearchParams) -> Path:
+def _flatten_organo(
+    organo: Optional[dict],
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Flatten organo nested object to nivel1, nivel2, nivel3."""
+    if not organo:
+        return None, None, None
+    return (
+        organo.get("nivel1"),
+        organo.get("nivel2"),
+        organo.get("nivel3"),
+    )
+
+
+def _convert_to_json_serializable(obj):
+    """Convert objects to JSON serializable format for JSONB columns."""
+    if obj is None:
+        return None
+    if isinstance(obj, (list, dict)):
+        return obj
+    # Handle any other complex types
+    return str(obj)
+
+
+def fetch_convocatoria_detalle(
+    numero_convocatoria: str,
+    rate_limiter: RateLimiter,
+    vpd: str = DEFAULT_VPD,
+) -> Optional[dict]:
     """
-    Scrape historical grants data and save to Parquet file.
-    This is for initial bulk load - generates Parquet for etl/ingest_l0.py to process.
+    Fetch detailed information for a single convocatoria.
+
+    Args:
+        numero_convocatoria: The convocatoria number to fetch details for
+        rate_limiter: RateLimiter instance (thread-safe)
+        vpd: VPD parameter (default: "GE")
+
+    Returns:
+        Dictionary with detailed convocatoria data or None if error
+    """
+    try:
+        rate_limiter.wait_if_needed()
+
+        params = {
+            "vpd": vpd,
+            "numConv": numero_convocatoria,
+        }
+
+        res = requests.get(API_ENDPOINT_DETAIL, params=params, timeout=30)
+
+        if res.status_code != 200:
+            _log(
+                "WARN",
+                f"Error al obtener detalle de convocatoria {numero_convocatoria}: HTTP {res.status_code}",
+            )
+            return None
+
+        data = res.json()
+
+        # Flatten organo
+        organo = data.get("organo", {})
+        nivel1, nivel2, nivel3 = _flatten_organo(organo)
+
+        # Build flattened record
+        record = {
+            "id": data.get("id"),
+            "nivel1": nivel1,
+            "nivel2": nivel2,
+            "nivel3": nivel3,
+            "sede_electronica": data.get("sedeElectronica"),
+            "codigo_bdns": data.get("codigoBDNS"),
+            "fecha_recepcion": data.get("fechaRecepcion"),
+            "instrumentos": _convert_to_json_serializable(data.get("instrumentos")),
+            "tipo_convocatoria": data.get("tipoConvocatoria"),
+            "presupuesto_total": data.get("presupuestoTotal"),
+            "mrr": data.get("mrr"),
+            "descripcion": data.get("descripcion"),
+            "descripcion_leng": data.get("descripcionLeng"),
+            "tipos_beneficiarios": _convert_to_json_serializable(
+                data.get("tiposBeneficiarios")
+            ),
+            "sectores": _convert_to_json_serializable(data.get("sectores")),
+            "regiones": _convert_to_json_serializable(data.get("regiones")),
+            "descripcion_finalidad": data.get("descripcionFinalidad"),
+            "descripcion_bases_reguladoras": data.get("descripcionBasesReguladoras"),
+            "url_bases_reguladoras": data.get("urlBasesReguladoras"),
+            "se_publica_diario_oficial": data.get("sePublicaDiarioOficial"),
+            "abierto": data.get("abierto"),
+            "fecha_inicio_solicitud": data.get("fechaInicioSolicitud"),
+            "fecha_fin_solicitud": data.get("fechaFinSolicitud"),
+            "text_inicio": data.get("textInicio"),
+            "text_fin": data.get("textFin"),
+            "ayuda_estado": data.get("ayudaEstado"),
+            "url_ayuda_estado": data.get("urlAyudaEstado"),
+            "fondos": _convert_to_json_serializable(data.get("fondos")),
+            "reglamento": _convert_to_json_serializable(data.get("reglamento")),
+            "objetivos": _convert_to_json_serializable(data.get("objetivos")),
+            "sectores_productos": _convert_to_json_serializable(
+                data.get("sectoresProductos")
+            ),
+            "documentos": _convert_to_json_serializable(data.get("documentos")),
+            "anuncios": _convert_to_json_serializable(data.get("anuncios")),
+            "advertencia": data.get("advertencia"),
+        }
+
+        return record
+
+    except Exception as e:
+        _log(
+            "ERROR",
+            f"Excepción al obtener detalle de convocatoria {numero_convocatoria}: {e}",
+        )
+        return None
+
+
+def scrape_historico(params: SearchParams, max_workers: int = 10) -> list[Path]:
+    """
+    Scrape historical grants data and save to Parquet files.
+    This is for initial bulk load - generates Parquet files for etl/ingest_l0.py to process.
+
+    Uses ThreadPool to fetch detailed information for each convocatoria in parallel.
+    Generates multiple parquet files with max 20000 records each.
 
     Args:
         params: SearchParams with date range (fechaDesde required, fechaHasta defaults to today)
+        max_workers: Number of threads for parallel detail fetching (default: 10)
 
     Returns:
-        Path to generated Parquet file
+        List of paths to generated Parquet files
     """
     if not params.fechaDesde:
         raise ValueError("fechaDesde es requerido para scrape historico")
@@ -175,7 +310,8 @@ def scrape_historico(params: SearchParams) -> Path:
 
     _ensure_output_dir()
 
-    all_records = []
+    # Step 1: Fetch all light convocatorias
+    light_convocatorias = []
     rate_limiter = RateLimiter(max_requests=49, time_window=60)
 
     page = params.page
@@ -183,12 +319,14 @@ def scrape_historico(params: SearchParams) -> Path:
     total_elements = 0
 
     print(f"\n{'='*60}", flush=True)
-    print(f"📦 SUBVENCIONES HISTÓRICAS (BDNS)", flush=True)
+    print(f"SUBVENCIONES HISTÓRICAS (BDNS)", flush=True)
     print(f"   Rango: {params.fechaDesde} — {params.fechaHasta}", flush=True)
     print(f"   Endpoint: {API_ENDPOINT_SEARCH}", flush=True)
     print(f"{'='*60}", flush=True)
 
     try:
+        # Fase 1: Obtener convocatorias ligeras
+        _log("INFO", "Fase 1: Obteniendo convocatorias ligeras...")
         while not is_last_page:
             params.page = page
 
@@ -226,42 +364,130 @@ def scrape_historico(params: SearchParams) -> Path:
                 break
 
             for item in content:
-                all_records.append(
+                light_convocatorias.append(
                     {
                         "id": item.get("id"),
                         "numero_convocatoria": item.get("numeroConvocatoria"),
-                        "mrr": item.get("mrr"),
-                        "descripcion": item.get("descripcion"),
-                        "descripcion_leng": item.get("descripcionLeng"),
-                        "fecha_recepcion": item.get("fechaRecepcion"),
-                        "nivel1": item.get("nivel1"),
-                        "nivel2": item.get("nivel2"),
-                        "nivel3": item.get("nivel3"),
-                        "codigo_invente": item.get("codigoInvente"),
                     }
                 )
 
-            pct = (len(all_records) / total_elements * 100) if total_elements else 0
+            pct = (
+                (len(light_convocatorias) / total_elements * 100)
+                if total_elements
+                else 0
+            )
             _log(
                 "INFO",
-                f"Página {page + 1}/{total_pages} — {len(all_records):,}/{total_elements:,} registros ({pct:.0f}%)",
+                f"Página {page + 1}/{total_pages} — {len(light_convocatorias):,}/{total_elements:,} convocatorias ({pct:.0f}%)",
             )
 
             page += 1
 
-        df = pd.DataFrame(all_records)
+        _log(
+            "INFO",
+            f"Fase 1 completada: {len(light_convocatorias):,} convocatorias obtenidas",
+        )
 
-        parquet_filename = f"licitaciones_subvenciones_{ano_inicio}_{ano_fin}.parquet"
-        parquet_path = OUTPUT_DIR / parquet_filename
+        # Fase 2: Obtener detalles en paralelo usando ThreadPool
+        _log(
+            "INFO",
+            f"Fase 2: Obteniendo detalles (ThreadPool con {max_workers} workers)...",
+        )
+        detailed_records = []
+        failed_count = 0
 
-        df.to_parquet(parquet_path, engine="pyarrow", index=False)
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            # Submit all tasks
+            future_to_conv = {
+                executor.submit(
+                    fetch_convocatoria_detalle,
+                    conv["numero_convocatoria"],
+                    rate_limiter,
+                ): conv
+                for conv in light_convocatorias
+            }
 
-        size_mb = parquet_path.stat().st_size / (1024 * 1024)
+            # Process completed tasks
+            for i, future in enumerate(as_completed(future_to_conv), 1):
+                try:
+                    result = future.result()
+                    if result:
+                        detailed_records.append(result)
+                    else:
+                        failed_count += 1
+                except Exception as e:
+                    _log("ERROR", f"Excepción en thread: {e}")
+                    failed_count += 1
+
+                # Progress update every 100 records
+                if i % 100 == 0 or i == len(light_convocatorias):
+                    pct = i / len(light_convocatorias) * 100
+                    _log(
+                        "INFO",
+                        f"Progreso: {i:,}/{len(light_convocatorias):,} ({pct:.1f}%) — Exitosos: {len(detailed_records):,}, Fallidos: {failed_count}",
+                    )
+
+        _log(
+            "INFO",
+            f"Fase 2 completada: {len(detailed_records):,} registros detallados obtenidos",
+        )
+
+        if failed_count > 0:
+            _log("WARN", f"{failed_count} convocatorias fallaron al obtener detalles")
+
+        if not detailed_records:
+            raise ValueError("No se obtuvieron registros detallados")
+
+        # Fase 3: Generar parquets en batches de MAX_RECORDS_PER_PARQUET
+        _log(
+            "INFO",
+            f"Fase 3: Generando parquets (máximo {MAX_RECORDS_PER_PARQUET:,} registros por archivo)...",
+        )
+        parquet_paths = []
+
+        for batch_idx in range(0, len(detailed_records), MAX_RECORDS_PER_PARQUET):
+            batch_records = detailed_records[
+                batch_idx : batch_idx + MAX_RECORDS_PER_PARQUET
+            ]
+            df = pd.DataFrame(batch_records)
+
+            # Ensure JSONB columns are properly serialized
+            jsonb_cols = [
+                "instrumentos",
+                "tipos_beneficiarios",
+                "sectores",
+                "regiones",
+                "fondos",
+                "reglamento",
+                "objetivos",
+                "sectores_productos",
+                "documentos",
+                "anuncios",
+            ]
+            for col in jsonb_cols:
+                if col in df.columns:
+                    df[col] = df[col].apply(
+                        lambda x: json.dumps(x) if x is not None else None
+                    )
+
+            batch_num = batch_idx // MAX_RECORDS_PER_PARQUET
+            parquet_filename = f"licitaciones_subvenciones_{ano_inicio}_{ano_fin}_batch{batch_num:03d}.parquet"
+            parquet_path = OUTPUT_DIR / parquet_filename
+
+            df.to_parquet(parquet_path, engine="pyarrow", index=False)
+            parquet_paths.append(parquet_path)
+
+            size_mb = parquet_path.stat().st_size / (1024 * 1024)
+            _log(
+                "INFO",
+                f"Parquet generado: {parquet_path.name} ({len(df):,} registros, {size_mb:.1f} MB)",
+            )
+
         print(f"\n✅ SCRAPING COMPLETADO: subvenciones históricas", flush=True)
-        _log("INFO", f"Parquet generado: {parquet_path.name} ({size_mb:.1f} MB)")
-        _log("INFO", f"Total registros: {len(df):,}")
+        _log("INFO", f"Total archivos parquet: {len(parquet_paths)}")
+        _log("INFO", f"Total registros: {len(detailed_records):,}")
 
-        return parquet_path
+        return parquet_paths
 
     except Exception as err:
         print(f"\n❌ ERROR: scraping histórico falló", flush=True)
@@ -273,6 +499,9 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
     """
     Scrape latest/daily grants and insert directly into database.
     This is for daily scheduler updates - small volume so direct insert is efficient.
+
+    Fetches detailed information for each convocatoria sequentially (no ThreadPool needed
+    for small volumes).
 
     Args:
         params: LatestParams for latest updates
@@ -298,7 +527,7 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
     print(f"\n{'='*60}", flush=True)
     print(f"SUBVENCIONES DIARIAS (BDNS)", flush=True)
     print(f"   Endpoint: {API_ENDPOINT_LATEST}", flush=True)
-    print(f"   Modo: insert directo en BD", flush=True)
+    print(f"   Modo: insert directo en BD con detalles completos", flush=True)
     print(f"{'='*60}", flush=True)
 
     try:
@@ -336,65 +565,159 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
             if not content:
                 break
 
+            # Filter and collect IDs
             page_filtered = 0
-            records = []
+            light_convocatorias = []
             for item in content:
                 descripcion = item.get("descripcion") or ""
                 if not subvencion_pattern.search(descripcion):
                     page_filtered += 1
                     continue
-                records.append(
-                    (
-                        item.get("id"),
-                        item.get("numeroConvocatoria"),
-                        item.get("mrr"),
-                        descripcion,
-                        item.get("descripcionLeng"),
-                        item.get("fechaRecepcion"),
-                        item.get("nivel1"),
-                        item.get("nivel2"),
-                        item.get("nivel3"),
-                        item.get("codigoInvente"),
-                    )
+                light_convocatorias.append(
+                    {
+                        "id": item.get("id"),
+                        "numero_convocatoria": item.get("numeroConvocatoria"),
+                    }
                 )
             total_filtered += page_filtered
 
-            if not records:
+            if not light_convocatorias:
                 page += 1
                 continue
 
+            # Check for duplicates
             with conn.cursor() as cur:
                 cur.execute(
                     "SELECT id FROM l0.nacional_subvenciones WHERE id = ANY(%s)",
-                    ([r[0] for r in records],),
+                    ([conv["id"] for conv in light_convocatorias],),
                 )
                 existing_ids = {row[0] for row in cur.fetchall()}
 
-                new_records = [r for r in records if r[0] not in existing_ids]
+                new_convocatorias = [
+                    conv
+                    for conv in light_convocatorias
+                    if conv["id"] not in existing_ids
+                ]
                 page_dups = len(existing_ids)
                 total_duplicates += page_dups
 
-                if new_records:
-                    execute_batch(
-                        cur,
-                        """
-                        INSERT INTO l0.nacional_subvenciones 
-                        (id, numero_convocatoria, mrr, descripcion, descripcion_leng,
-                         fecha_recepcion, nivel1, nivel2, nivel3, codigo_invente)
-                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                        """,
-                        new_records,
-                        page_size=params.pageSize,
-                    )
-                    conn.commit()
-                    total_new += len(new_records)
+                if not new_convocatorias:
+                    _log("INFO", f"Página {page + 1}: {page_dups} duplicados, 0 nuevos")
+                    # If we found duplicates, stop searching (assuming chronological order)
+                    if existing_ids:
+                        break
+                    page += 1
+                    continue
 
+                # Fetch details for new convocatorias (sequential, no ThreadPool)
+                _log(
+                    "INFO",
+                    f"Obteniendo detalles para {len(new_convocatorias)} nuevas convocatorias...",
+                )
+                detailed_records = []
+                for i, conv in enumerate(new_convocatorias, 1):
+                    detail = fetch_convocatoria_detalle(
+                        conv["numero_convocatoria"], rate_limiter
+                    )
+                    if detail:
+                        detailed_records.append(detail)
+                    else:
+                        _log(
+                            "WARN",
+                            f"No se pudo obtener detalle para {conv['numero_convocatoria']}",
+                        )
+
+                    if i % 10 == 0:
+                        _log("INFO", f"Progreso detalles: {i}/{len(new_convocatorias)}")
+
+                if not detailed_records:
+                    _log("WARN", "No se obtuvieron registros detallados válidos")
+                    page += 1
+                    continue
+
+                # Insert detailed records
+                insert_sql = """
+                    INSERT INTO l0.nacional_subvenciones 
+                    (id, nivel1, nivel2, nivel3, sede_electronica, codigo_bdns, fecha_recepcion,
+                     instrumentos, tipo_convocatoria, presupuesto_total, mrr, descripcion, descripcion_leng,
+                     tipos_beneficiarios, sectores, regiones, descripcion_finalidad, descripcion_bases_reguladoras,
+                     url_bases_reguladoras, se_publica_diario_oficial, abierto, fecha_inicio_solicitud,
+                     fecha_fin_solicitud, text_inicio, text_fin, ayuda_estado, url_ayuda_estado,
+                     fondos, reglamento, objetivos, sectores_productos, documentos, anuncios, advertencia)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (id) DO NOTHING
+                """
+
+                records_to_insert = []
+                for record in detailed_records:
+                    # Serialize JSONB columns
+                    jsonb_cols = [
+                        "instrumentos",
+                        "tipos_beneficiarios",
+                        "sectores",
+                        "regiones",
+                        "fondos",
+                        "reglamento",
+                        "objetivos",
+                        "sectores_productos",
+                        "documentos",
+                        "anuncios",
+                    ]
+                    for col in jsonb_cols:
+                        if record.get(col) is not None:
+                            record[col] = json.dumps(record[col])
+
+                    records_to_insert.append(
+                        (
+                            record.get("id"),
+                            record.get("nivel1"),
+                            record.get("nivel2"),
+                            record.get("nivel3"),
+                            record.get("sede_electronica"),
+                            record.get("codigo_bdns"),
+                            record.get("fecha_recepcion"),
+                            record.get("instrumentos"),
+                            record.get("tipo_convocatoria"),
+                            record.get("presupuesto_total"),
+                            record.get("mrr"),
+                            record.get("descripcion"),
+                            record.get("descripcion_leng"),
+                            record.get("tipos_beneficiarios"),
+                            record.get("sectores"),
+                            record.get("regiones"),
+                            record.get("descripcion_finalidad"),
+                            record.get("descripcion_bases_reguladoras"),
+                            record.get("url_bases_reguladoras"),
+                            record.get("se_publica_diario_oficial"),
+                            record.get("abierto"),
+                            record.get("fecha_inicio_solicitud"),
+                            record.get("fecha_fin_solicitud"),
+                            record.get("text_inicio"),
+                            record.get("text_fin"),
+                            record.get("ayuda_estado"),
+                            record.get("url_ayuda_estado"),
+                            record.get("fondos"),
+                            record.get("reglamento"),
+                            record.get("objetivos"),
+                            record.get("sectores_productos"),
+                            record.get("documentos"),
+                            record.get("anuncios"),
+                            record.get("advertencia"),
+                        )
+                    )
+
+                execute_batch(cur, insert_sql, records_to_insert, page_size=100)
+                conn.commit()
+                total_new += len(records_to_insert)
+                _log("INFO", f"Insertados {len(records_to_insert)} registros nuevos")
+
+                # If we found duplicates, stop searching
                 if existing_ids:
                     break
 
             page += 1
 
-        print(f"\nSCRAPING COMPLETADO: subvenciones diarias", flush=True)
+        print(f"\n✅ SCRAPING COMPLETADO: subvenciones diarias", flush=True)
 
         return {
             "inserted": total_new,
@@ -460,9 +783,12 @@ def main():
             fechaHasta=fecha_hasta,
         )
 
-        parquet_path = scrape_historico(params)
+        parquet_paths = scrape_historico(params)
         if args.solo_descargar:
-            print("   (--solo-descargar: no se cargará en BD)")
+            print(f"   (--solo-descargar: no se cargará en BD)")
+            print(f"   Archivos generados: {len(parquet_paths)}")
+            for path in parquet_paths:
+                print(f"     - {path.name}")
 
         return 0
 

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -35,7 +35,7 @@ API_ENDPOINT_DETAIL = API_BASE_URL
 DEFAULT_VPD = "GE"
 
 # Maximum records per parquet file
-MAX_RECORDS_PER_PARQUET = 100
+MAX_RECORDS_PER_PARQUET = 10000
 
 # Directory configuration (similar to nacional/licitaciones.py)
 _repo_root = Path(__file__).resolve().parent.parent
@@ -464,9 +464,8 @@ def scrape_diario(params: SearchParams) -> dict[str, int]:
         cur = conn.cursor()
 
         # Get the most recent fecha_recepcion from DB to use as fechaDesde
-        cur.execute(
-            "SELECT MAX(fecha_recepcion) FROM l0.nacional_subvenciones WHERE fecha_recepcion IS NOT NULL"
-        )
+        # Order by id DESC (indexed) for fast lookup - higher id = more recent
+        cur.execute("SELECT fecha_recepcion FROM l0.nacional_subvenciones ORDER BY id DESC LIMIT 1")
         result = cur.fetchone()
         max_fecha = result[0] if result and result[0] else None
 
@@ -475,9 +474,11 @@ def scrape_diario(params: SearchParams) -> dict[str, int]:
             params.fechaDesde = max_fecha.strftime("%d/%m/%Y")
             _log("INFO", f"Buscando desde fecha más reciente en BD: {params.fechaDesde}")
         else:
-            # If no records in DB, don't set fechaDesde (get all records)
-            params.fechaDesde = None
-            _log("INFO", "No hay registros en BD, obteniendo todas las convocatorias")
+            raise ValueError(
+                "No hay registros en la base de datos. "
+                "Ejecuta primero '... licitia-etl ingest nacional subvenciones --anos YYYY-YYYY' "
+                "para cargar datos históricos antes de realizar el scrape diario."
+            )
 
         # Set fechaHasta to current date
         params.fechaHasta = datetime.now().strftime("%d/%m/%Y")
@@ -703,15 +704,13 @@ def main():
     if len(partes) > 1:
         ano_fin = int(partes[1])
         if ano_fin == datetime.now().year:
-            # fecha_hasta = datetime.now().strftime("%d/%m/%Y")
-            fecha_hasta = "19/04/2026"
+            fecha_hasta = datetime.now().strftime("%d/%m/%Y")
         else:
             fecha_hasta = f"31/12/{ano_fin}"
     else:
         fecha_hasta = datetime.now().strftime("%d/%m/%Y")
 
-    # fecha_desde = f"01/01/{ano_inicio}"
-    fecha_desde = f"16/04/2026"
+    fecha_desde = f"01/01/{ano_inicio}"
     _log("INFO", f"Fechas: {fecha_desde} - {fecha_hasta}")
     _log("INFO", f"Conjunto: {args.conjunto}")
 

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -949,15 +949,13 @@ def main():
     if len(partes) > 1:
         ano_fin = int(partes[1])
         if ano_fin == datetime.now().year:
-            # fecha_hasta = datetime.now().strftime("%d/%m/%Y")
-            fecha_hasta = "21/04/2026"
+            fecha_hasta = datetime.now().strftime("%d/%m/%Y")
         else:
             fecha_hasta = f"31/12/{ano_fin}"
     else:
         fecha_hasta = datetime.now().strftime("%d/%m/%Y")
 
-    # fecha_desde = f"01/01/{ano_inicio}"
-    fecha_desde = "17/04/2026"
+    fecha_desde = f"01/01/{ano_inicio}"
 
     try:
         params = SearchParams(

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -190,12 +190,12 @@ def fetch_convocatoria_detalle(
 
             # Build flattened record
             record = {
-                "id": data.get("id"),
+                # codigoBDNS = numeroConvocatoria en datos ligeros
+                "id": data.get("codigoBDNS"),
                 "nivel1": nivel1,
                 "nivel2": nivel2,
                 "nivel3": nivel3,
                 "sede_electronica": data.get("sedeElectronica"),
-                "codigo_bdns": data.get("codigoBDNS"),
                 "fecha_recepcion": data.get("fechaRecepcion"),
                 "instrumentos": _convert_to_json_serializable(data.get("instrumentos")),
                 "tipo_convocatoria": data.get("tipoConvocatoria"),
@@ -457,7 +457,6 @@ def scrape_diario(params: SearchParams) -> dict[str, int]:
     total_new = 0
     total_duplicates = 0
     total_filtered = 0
-    subvencion_pattern = re.compile(r"subvenci[oó]n", re.IGNORECASE)
 
     _log("INFO", "Obteniendo convocatorias nuevas...")
     try:
@@ -520,10 +519,6 @@ def scrape_diario(params: SearchParams) -> dict[str, int]:
             page_filtered = 0
             light_convocatorias = []
             for item in content:
-                descripcion = item.get("descripcion") or ""
-                if not subvencion_pattern.search(descripcion):
-                    page_filtered += 1
-                    continue
                 numero_conv = item.get("numeroConvocatoria")
                 if numero_conv:
                     light_convocatorias.append({"id": int(numero_conv)})
@@ -614,7 +609,6 @@ def scrape_diario(params: SearchParams) -> dict[str, int]:
                     record.get("nivel2"),
                     record.get("nivel3"),
                     record.get("sede_electronica"),
-                    record.get("codigo_bdns"),
                     record.get("fecha_recepcion"),
                     record.get("instrumentos"),
                     record.get("tipo_convocatoria"),
@@ -647,13 +641,13 @@ def scrape_diario(params: SearchParams) -> dict[str, int]:
 
         insert_sql = """
             INSERT INTO l0.nacional_subvenciones 
-            (id, nivel1, nivel2, nivel3, sede_electronica, codigo_bdns, fecha_recepcion,
+            (id, nivel1, nivel2, nivel3, sede_electronica, fecha_recepcion,
              instrumentos, tipo_convocatoria, presupuesto_total, mrr, descripcion, descripcion_leng,
              tipos_beneficiarios, sectores, regiones, descripcion_finalidad, descripcion_bases_reguladoras,
              url_bases_reguladoras, se_publica_diario_oficial, abierto, fecha_inicio_solicitud,
              fecha_fin_solicitud, text_inicio, text_fin, ayuda_estado, url_ayuda_estado,
              fondos, reglamento, objetivos, sectores_productos, documentos, anuncios)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (id) DO NOTHING
         """
 

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -371,6 +371,24 @@ def _convert_to_json_serializable(obj):
     return str(obj)
 
 
+def _is_expired_grant(record: dict) -> bool:
+    """
+    Returns True if the grant should be discarded:
+    - abierto is False AND fecha_fin_solicitud < today
+    Records without fecha_fin_solicitud are kept.
+    """
+    if record.get("abierto"):
+        return False
+    fecha_fin = record.get("fecha_fin_solicitud")
+    if not fecha_fin:
+        return False
+    try:
+        # API returns YYYY-MM-DD, compare as ISO string (lexicographic order works)
+        return fecha_fin < datetime.now().strftime("%Y-%m-%d")
+    except Exception:
+        return False
+
+
 def fetch_convocatoria_detalle(
     numero_convocatoria: str,
 ) -> dict | None:
@@ -572,6 +590,7 @@ def scrape_historico(params: SearchParams) -> list[Path]:
         parquet_paths = []
         batch_num = [0]  # Shared between threads
         total_saved = [0]  # Shared between threads
+        skipped_expired = [0]  # Shared between threads
         fetching_done = threading.Event()
 
         # Only these columns need JSON serialization now
@@ -625,6 +644,10 @@ def scrape_historico(params: SearchParams) -> list[Path]:
             while not (fetching_done.is_set() and buffer.empty()):
                 try:
                     record = buffer.get(timeout=1)
+                    if _is_expired_grant(record):
+                        skipped_expired[0] += 1
+                        buffer.task_done()
+                        continue
                     batch_buffer.append(record)
 
                     if len(batch_buffer) >= MAX_RECORDS_PER_PARQUET:
@@ -665,6 +688,9 @@ def scrape_historico(params: SearchParams) -> list[Path]:
 
         if failed_count > 0:
             _log("WARN", f"{failed_count} convocatorias fallaron")
+
+        if skipped_expired[0] > 0:
+            _log("INFO", f"{skipped_expired[0]} convocatorias descartadas (cerradas y caducadas)")
 
         if not parquet_paths:
             raise ValueError("No se generaron parquets (sin registros válidos)")
@@ -816,10 +842,16 @@ def scrape_diario(params: SearchParams) -> dict[str, int]:
         # FASE 2: Obtener detalles de todas las convocatorias e insertar
         detailed_records = []
         _log("INFO", "Obteniendo detalles de las nuevas convocatorias encontradas...")
+        skipped_expired = 0
         for conv in tqdm(all_new_convocatorias, unit="conv"):
             detail = fetch_convocatoria_detalle(str(conv["id"]))
             if detail:
-                detailed_records.append(detail)
+                if _is_expired_grant(detail):
+                    skipped_expired += 1
+                else:
+                    detailed_records.append(detail)
+        if skipped_expired:
+            _log("INFO", f"{skipped_expired} convocatorias descartadas (cerradas y caducadas)")
 
         if not detailed_records:
             _log("INFO", "No se pudieron obtener detalles de las convocatorias")

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -12,6 +12,8 @@ import argparse
 import re
 import json
 from tqdm import tqdm
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import threading
 
 LOG_PREFIX = "[subvenciones]"
 
@@ -47,20 +49,13 @@ def _ensure_output_dir():
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 
+@dataclass
 class RateLimiter:
     """Manage API rate limiting to avoid exceeding request limits and get API ban."""
 
-    def __init__(self, max_requests: int = 49, time_window: int = 60):
-        """
-        Initialize rate limiter.
-
-        Args:
-            max_requests: Maximum requests allowed in time window (default 49 to stay safe)
-            time_window: Time window in seconds (default 60 for 1 minute)
-        """
-        self.max_requests = max_requests
-        self.time_window = time_window
-        self.request_times = []
+    max_requests: int = field(default=49)
+    time_window: int = field(default=60)
+    request_times: list = field(default_factory=list, init=False)
 
     def wait_if_needed(self):
         """Wait if necessary to avoid exceeding rate limit."""
@@ -259,17 +254,16 @@ def fetch_convocatoria_detalle(
         return None
 
 
-def scrape_historico(params: SearchParams) -> list[Path]:
+def scrape_historico(params: SearchParams, max_workers: int = 1) -> list[Path]:
     """
     Scrape historical grants data and save to Parquet files.
     This is for initial bulk load - generates Parquet files for etl/ingest_l0.py to process.
 
-    Fetches detailed information for each convocatoria sequentially (no parallelism needed
-    due to strict API rate limiting of 50 req/min).
     Generates multiple parquet files with max 20000 records each.
 
     Args:
         params: SearchParams with date range (fechaDesde required, fechaHasta defaults to today)
+        max_workers: Number of threads for parallel fetching (default: 1 = sequential)
 
     Returns:
         List of paths to generated Parquet files
@@ -280,7 +274,7 @@ def scrape_historico(params: SearchParams) -> list[Path]:
     params.validate()
 
     _ensure_output_dir()
-    rate_limiter = RateLimiter(max_requests=59, time_window=60)
+    rate_limiter = RateLimiter(max_requests=200, time_window=60)
 
     _log("INFO", "=" * 60)
     _log("INFO", "SUBVENCIONES HISTÓRICAS (BDNS)")
@@ -335,10 +329,12 @@ def scrape_historico(params: SearchParams) -> list[Path]:
 
         _log("INFO", f"{len(light_convocatorias):,} convocatorias obtenidas")
 
-        _log("INFO", f"Obteniendo detalles y generando parquets...")
+        _log("INFO", f"Obteniendo detalles y generando parquets (workers: {max_workers})...")
 
         batch_buffer = []
+        batch_buffer_lock = threading.Lock() if max_workers > 1 else None
         failed_count = 0
+        failed_lock = threading.Lock() if max_workers > 1 else None
         parquet_paths = []
         batch_num = 0
         total_saved = 0
@@ -379,24 +375,61 @@ def scrape_historico(params: SearchParams) -> list[Path]:
             )
             return parquet_path
 
-        for conv in tqdm(light_convocatorias, unit="conv"):
-            try:
-                result = fetch_convocatoria_detalle(conv["numero_convocatoria"], rate_limiter)
-                if result:
-                    batch_buffer.append(result)
+        if max_workers > 1:
+            # Modo paralelo con ThreadPool
+            def process_convocatoria(conv):
+                nonlocal batch_num, total_saved, failed_count
 
-                    if len(batch_buffer) >= MAX_RECORDS_PER_PARQUET:
-                        parquet_path = save_batch(batch_buffer, batch_num)
-                        if parquet_path:
-                            parquet_paths.append(parquet_path)
-                            total_saved += len(batch_buffer)
-                        batch_buffer = []
-                        batch_num += 1
-                else:
+                try:
+                    result = fetch_convocatoria_detalle(conv["numero_convocatoria"], rate_limiter)
+                    if result:
+                        with batch_buffer_lock:
+                            batch_buffer.append(result)
+
+                            if len(batch_buffer) >= MAX_RECORDS_PER_PARQUET:
+                                parquet_path = save_batch(batch_buffer[:], batch_num)
+                                if parquet_path:
+                                    parquet_paths.append(parquet_path)
+                                    total_saved += len(batch_buffer)
+                                batch_buffer.clear()
+                                batch_num += 1
+                    else:
+                        with failed_lock:
+                            failed_count += 1
+                except Exception as e:
+                    _log("ERROR", f"Excepción: {e}")
+                    with failed_lock:
+                        failed_count += 1
+
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = [
+                    executor.submit(process_convocatoria, conv) for conv in light_convocatorias
+                ]
+
+                with tqdm(total=len(light_convocatorias), unit="conv") as pbar:
+                    for future in as_completed(futures):
+                        future.result()
+                        pbar.update(1)
+        else:
+            # Modo secuencial (original)
+            for conv in tqdm(light_convocatorias, unit="conv"):
+                try:
+                    result = fetch_convocatoria_detalle(conv["numero_convocatoria"], rate_limiter)
+                    if result:
+                        batch_buffer.append(result)
+
+                        if len(batch_buffer) >= MAX_RECORDS_PER_PARQUET:
+                            parquet_path = save_batch(batch_buffer, batch_num)
+                            if parquet_path:
+                                parquet_paths.append(parquet_path)
+                                total_saved += len(batch_buffer)
+                            batch_buffer = []
+                            batch_num += 1
+                    else:
+                        failed_count += 1
+                except Exception as e:
+                    _log("ERROR", f"Excepción: {e}")
                     failed_count += 1
-            except Exception as e:
-                _log("ERROR", f"Excepción: {e}")
-                failed_count += 1
 
         if batch_buffer:
             parquet_path = save_batch(batch_buffer, batch_num)
@@ -655,6 +688,12 @@ def main():
         action="store_true",
         help="Solo descargar/generar Parquet, no cargar en BD",
     )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        help="Número de workers para ThreadPool (default: 1 = secuencial)",
+    )
 
     args = parser.parse_args()
 
@@ -685,7 +724,10 @@ def main():
             fechaHasta=fecha_hasta,
         )
 
-        parquet_paths = scrape_historico(params)
+        workers = getattr(args, "workers", 1)
+        _log("INFO", f"Usando {workers} worker(s) para fetching")
+
+        parquet_paths = scrape_historico(params, max_workers=workers)
         if args.solo_descargar:
             _log("INFO", "(--solo-descargar: no se cargará en BD)")
             _log("INFO", f"Archivos generados: {len(parquet_paths)}")

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -43,6 +43,10 @@ _repo_root = Path(__file__).resolve().parent.parent
 _tmp_base = Path(os.environ.get("LICITACIONES_TMP_DIR", _repo_root / "tmp"))
 OUTPUT_DIR = _tmp_base / "output"
 
+# Global adaptive delay for rate limit control (shared across all API calls)
+_api_delay_seconds = 0  # Start with no delay, adjust only if rate limited
+_api_delay_lock = threading.Lock()  # Thread-safe access to delay variable
+
 
 def _ensure_output_dir():
     """Ensure output directory exists."""
@@ -142,7 +146,8 @@ def fetch_convocatoria_detalle(
 ) -> dict | None:
     """
     Fetch detailed information for a single convocatoria.
-    Implements progressive retry with 4 attempts: 5s, 15s, 25s, 40s delays.
+    Uses adaptive exponential delay to handle rate limiting automatically.
+    Delay starts at 25ms and increases exponentially on 429 errors.
 
     Args:
         numero_convocatoria: The convocatoria number to fetch details for
@@ -150,33 +155,42 @@ def fetch_convocatoria_detalle(
     Returns:
         Dictionary with detailed convocatoria data or None if error
     """
+    global _api_delay_seconds
+
     params = {
         "vpd": DEFAULT_VPD,
         "numConv": numero_convocatoria,
     }
 
-    max_retries = 4
-    retry_delays = [5, 15, 25, 40]  # Progressive delays in seconds
+    max_attempts = 10  # Maximum attempts before giving up
 
-    for attempt in range(max_retries):
+    for attempt in range(max_attempts):
+        # Apply adaptive delay before request
+        with _api_delay_lock:
+            current_delay = _api_delay_seconds
+
+        if current_delay > 0:
+            time.sleep(current_delay)
+
         try:
             res = requests.get(API_ENDPOINT_DETAIL, params=params, timeout=30)
 
             if res.status_code == 429:
-                if attempt < max_retries - 1:
-                    delay = retry_delays[attempt]
-                    _log(
-                        "WARN",
-                        f"HTTP 429 para convocatoria {numero_convocatoria}, esperando {delay}s antes de reintentar (intento {attempt + 1}/{max_retries})...",
-                    )
-                    time.sleep(delay)
-                    continue
-                else:
-                    _log(
-                        "ERROR",
-                        f"HTTP 429 para convocatoria {numero_convocatoria} después de {max_retries} intentos",
-                    )
-                    return None
+                # Increase delay on rate limit
+                # First time: set to 25ms, then increase by ×1.6 factor
+                with _api_delay_lock:
+                    if _api_delay_seconds == 0:
+                        _api_delay_seconds = 0.025  # First rate limit: start at 25ms
+                    else:
+                        _api_delay_seconds *= 1.6  # Subsequent: gradual exponential increase
+
+                    new_delay = _api_delay_seconds
+
+                _log(
+                    "WARN",
+                    f"HTTP 429 (rate limit), incrementando delay a {new_delay * 1000:.1f}ms (intento {attempt + 1}/{max_attempts})",
+                )
+                continue
 
             if res.status_code != 200:
                 _log(
@@ -233,21 +247,17 @@ def fetch_convocatoria_detalle(
             return record
 
         except Exception as e:
-            if attempt < max_retries - 1:
-                delay = retry_delays[attempt]
-                _log(
-                    "WARN",
-                    f"Excepción al obtener convocatoria {numero_convocatoria} (intento {attempt + 1}/{max_retries}): {e}, esperando {delay}s...",
-                )
-                time.sleep(delay)
-                continue
-            else:
-                _log(
-                    "ERROR",
-                    f"Excepción al obtener detalle de convocatoria {numero_convocatoria}: {e}",
-                )
-                return None
+            _log(
+                "ERROR",
+                f"Excepción al obtener convocatoria {numero_convocatoria}: {e}",
+            )
+            return None
 
+    # If we exhausted all attempts
+    _log(
+        "ERROR",
+        f"No se pudo obtener convocatoria {numero_convocatoria} después de {max_attempts} intentos",
+    )
     return None
 
 
@@ -470,6 +480,7 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
         )
 
     conn = None
+    cur = None
     total_new = 0
     total_duplicates = 0
     total_filtered = 0
@@ -479,6 +490,7 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
 
     try:
         conn = psycopg2.connect(db_url)
+        cur = conn.cursor()  # Open cursor once at the start
 
         page = params.page
         is_last_page = False
@@ -532,118 +544,125 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
                 page += 1
                 continue
 
-            # Check for duplicates
-            with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT id FROM l0.nacional_subvenciones WHERE id = ANY(%s)",
-                    ([conv["numero_convocatoria"] for conv in light_convocatorias],),
-                )
-                existing_ids = {row[0] for row in cur.fetchall()}
+            # Check for duplicates using the persistent cursor
+            cur.execute(
+                "SELECT id FROM l0.nacional_subvenciones WHERE id = ANY(%s)",
+                ([conv["numero_convocatoria"] for conv in light_convocatorias],),
+            )
+            existing_ids = {row[0] for row in cur.fetchall()}
 
-                new_convocatorias = [
-                    conv
-                    for conv in light_convocatorias
-                    if conv["numero_convocatoria"] not in existing_ids
-                ]
-                page_dups = len(existing_ids)
-                total_duplicates += page_dups
+            new_convocatorias = [
+                conv
+                for conv in light_convocatorias
+                if conv["numero_convocatoria"] not in existing_ids
+            ]
+            page_dups = len(existing_ids)
+            total_duplicates += page_dups
 
-                if not new_convocatorias:
-                    # If we found duplicates, stop searching
-                    if existing_ids:
-                        break
-                    page += 1
-                    continue
+            # Show progress message for this page
+            _log(
+                "INFO",
+                f"Para la página número {page + 1} se han encontrado {len(new_convocatorias)} convocatorias nuevas",
+            )
 
-                # Fetch details for new convocatorias (sequential, opción 1)
-                detailed_records = []
-                _log("INFO", "Obteniendo detalles de convocatorias...")
-                for conv in tqdm(new_convocatorias, unit="conv"):
-                    # Convert back to string for API request
-                    detail = fetch_convocatoria_detalle(str(conv["numero_convocatoria"]))
-                    if detail:
-                        detailed_records.append(detail)
-
-                if not detailed_records:
-                    page += 1
-                    continue
-
-                # Insert detailed records
-                insert_sql = """
-                    INSERT INTO l0.nacional_subvenciones 
-                    (id, nivel1, nivel2, nivel3, sede_electronica, codigo_bdns, fecha_recepcion,
-                     instrumentos, tipo_convocatoria, presupuesto_total, mrr, descripcion, descripcion_leng,
-                     tipos_beneficiarios, sectores, regiones, descripcion_finalidad, descripcion_bases_reguladoras,
-                     url_bases_reguladoras, se_publica_diario_oficial, abierto, fecha_inicio_solicitud,
-                     fecha_fin_solicitud, text_inicio, text_fin, ayuda_estado, url_ayuda_estado,
-                     fondos, reglamento, objetivos, sectores_productos, documentos, anuncios)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                    ON CONFLICT (id) DO NOTHING
-                """
-
-                records_to_insert = []
-                for record in detailed_records:
-                    # Serialize JSONB columns
-                    jsonb_cols = [
-                        "instrumentos",
-                        "tipos_beneficiarios",
-                        "sectores",
-                        "regiones",
-                        "fondos",
-                        "reglamento",
-                        "objetivos",
-                        "sectores_productos",
-                        "documentos",
-                        "anuncios",
-                    ]
-                    for col in jsonb_cols:
-                        if record.get(col) is not None:
-                            record[col] = json.dumps(record[col])
-
-                    records_to_insert.append(
-                        (
-                            record.get("id"),
-                            record.get("nivel1"),
-                            record.get("nivel2"),
-                            record.get("nivel3"),
-                            record.get("sede_electronica"),
-                            record.get("codigo_bdns"),
-                            record.get("fecha_recepcion"),
-                            record.get("instrumentos"),
-                            record.get("tipo_convocatoria"),
-                            record.get("presupuesto_total"),
-                            record.get("mrr"),
-                            record.get("descripcion"),
-                            record.get("descripcion_leng"),
-                            record.get("tipos_beneficiarios"),
-                            record.get("sectores"),
-                            record.get("regiones"),
-                            record.get("descripcion_finalidad"),
-                            record.get("descripcion_bases_reguladoras"),
-                            record.get("url_bases_reguladoras"),
-                            record.get("se_publica_diario_oficial"),
-                            record.get("abierto"),
-                            record.get("fecha_inicio_solicitud"),
-                            record.get("fecha_fin_solicitud"),
-                            record.get("text_inicio"),
-                            record.get("text_fin"),
-                            record.get("ayuda_estado"),
-                            record.get("url_ayuda_estado"),
-                            record.get("fondos"),
-                            record.get("reglamento"),
-                            record.get("objetivos"),
-                            record.get("sectores_productos"),
-                            record.get("documentos"),
-                            record.get("anuncios"),
-                        )
-                    )
-
-                execute_batch(cur, insert_sql, records_to_insert)
-                conn.commit()
-                total_new += len(records_to_insert)
-
+            if not new_convocatorias:
+                # If we found duplicates, stop searching
                 if existing_ids:
+                    _log("INFO", "Ya se encontraron todas las convocatorias recientes")
                     break
+                page += 1
+                continue
+
+            detailed_records = []
+            for conv in enumerate(new_convocatorias):
+                # Convert back to string for API request
+                detail = fetch_convocatoria_detalle(str(conv["numero_convocatoria"]))
+                if detail:
+                    detailed_records.append(detail)
+
+            if not detailed_records:
+                page += 1
+                continue
+
+            records_to_insert = []
+            for record in detailed_records:
+                # Serialize JSONB columns
+                jsonb_cols = [
+                    "instrumentos",
+                    "tipos_beneficiarios",
+                    "sectores",
+                    "regiones",
+                    "fondos",
+                    "reglamento",
+                    "objetivos",
+                    "sectores_productos",
+                    "documentos",
+                    "anuncios",
+                ]
+                for col in jsonb_cols:
+                    if record.get(col) is not None:
+                        record[col] = json.dumps(record[col])
+
+                records_to_insert.append(
+                    (
+                        record.get("id"),
+                        record.get("nivel1"),
+                        record.get("nivel2"),
+                        record.get("nivel3"),
+                        record.get("sede_electronica"),
+                        record.get("codigo_bdns"),
+                        record.get("fecha_recepcion"),
+                        record.get("instrumentos"),
+                        record.get("tipo_convocatoria"),
+                        record.get("presupuesto_total"),
+                        record.get("mrr"),
+                        record.get("descripcion"),
+                        record.get("descripcion_leng"),
+                        record.get("tipos_beneficiarios"),
+                        record.get("regiones"),
+                        record.get("sectores"),
+                        record.get("descripcion_finalidad"),
+                        record.get("descripcion_bases_reguladoras"),
+                        record.get("url_bases_reguladoras"),
+                        record.get("se_publica_diario_oficial"),
+                        record.get("abierto"),
+                        record.get("fecha_inicio_solicitud"),
+                        record.get("fecha_fin_solicitud"),
+                        record.get("text_inicio"),
+                        record.get("text_fin"),
+                        record.get("ayuda_estado"),
+                        record.get("url_ayuda_estado"),
+                        record.get("fondos"),
+                        record.get("reglamento"),
+                        record.get("objetivos"),
+                        record.get("sectores_productos"),
+                        record.get("documentos"),
+                        record.get("anuncios"),
+                    )
+                )
+
+            # Insert using the persistent cursor
+            insert_sql = """
+                INSERT INTO l0.nacional_subvenciones 
+                (id, nivel1, nivel2, nivel3, sede_electronica, codigo_bdns, fecha_recepcion,
+                 instrumentos, tipo_convocatoria, presupuesto_total, mrr, descripcion, descripcion_leng,
+                 tipos_beneficiarios, sectores, regiones, descripcion_finalidad, descripcion_bases_reguladoras,
+                 url_bases_reguladoras, se_publica_diario_oficial, abierto, fecha_inicio_solicitud,
+                 fecha_fin_solicitud, text_inicio, text_fin, ayuda_estado, url_ayuda_estado,
+                 fondos, reglamento, objetivos, sectores_productos, documentos, anuncios)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (id) DO NOTHING
+            """
+
+            execute_batch(cur, insert_sql, records_to_insert)
+            conn.commit()
+
+            _log("INFO", f"  Insertados {len(records_to_insert)} registros en BD")
+            total_new += len(records_to_insert)
+
+            if existing_ids:
+                _log("INFO", "Ya se encontraron todas las convocatorias recientes")
+                break
 
             page += 1
 
@@ -666,6 +685,8 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
         raise
     finally:
         if conn:
+            if cur:
+                cur.close()
             conn.close()
 
 
@@ -697,14 +718,14 @@ def main():
         ano_fin = int(partes[1])
         if ano_fin == datetime.now().year:
             # fecha_hasta = datetime.now().strftime("%d/%m/%Y")
-            fecha_hasta = "18/04/2026"
+            fecha_hasta = "19/04/2026"
         else:
             fecha_hasta = f"31/12/{ano_fin}"
     else:
         fecha_hasta = datetime.now().strftime("%d/%m/%Y")
 
     # fecha_desde = f"01/01/{ano_inicio}"
-    fecha_desde = f"10/04/2026"
+    fecha_desde = f"19/04/2026"
     _log("INFO", f"Fechas: {fecha_desde} - {fecha_hasta}")
     _log("INFO", f"Conjunto: {args.conjunto}")
 

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -12,8 +12,6 @@ import argparse
 import re
 import json
 from tqdm import tqdm
-from concurrent.futures import ThreadPoolExecutor, as_completed
-import threading
 
 LOG_PREFIX = "[subvenciones]"
 
@@ -53,7 +51,7 @@ def _ensure_output_dir():
 class RateLimiter:
     """Manage API rate limiting to avoid exceeding request limits and get API ban."""
 
-    max_requests: int = field(default=49)
+    max_requests: int = field(default=50)
     time_window: int = field(default=60)
     request_times: list = field(default_factory=list, init=False)
 
@@ -254,16 +252,16 @@ def fetch_convocatoria_detalle(
         return None
 
 
-def scrape_historico(params: SearchParams, max_workers: int = 3) -> list[Path]:
+def scrape_historico(params: SearchParams) -> list[Path]:
     """
     Scrape historical grants data and save to Parquet files.
     This is for initial bulk load - generates Parquet files for etl/ingest_l0.py to process.
 
     Generates multiple parquet files with max 20000 records each.
+    Mode: Sequential (endpoint de detalles tiene rate limit de ~20 req/min).
 
     Args:
         params: SearchParams with date range (fechaDesde required, fechaHasta defaults to today)
-        max_workers: Number of threads for parallel fetching (default: 3)
 
     Returns:
         List of paths to generated Parquet files
@@ -274,7 +272,8 @@ def scrape_historico(params: SearchParams, max_workers: int = 3) -> list[Path]:
     params.validate()
 
     _ensure_output_dir()
-    rate_limiter = RateLimiter(max_requests=200, time_window=60)
+    # Rate limiter: endpoint de detalles tiene límite ~20 req/min
+    rate_limiter = RateLimiter(max_requests=20, time_window=60)
 
     _log("INFO", "=" * 60)
     _log("INFO", "SUBVENCIONES HISTÓRICAS (BDNS)")
@@ -328,13 +327,10 @@ def scrape_historico(params: SearchParams, max_workers: int = 3) -> list[Path]:
                 pbar.update(1)
 
         _log("INFO", f"{len(light_convocatorias):,} convocatorias obtenidas")
-
-        _log("INFO", f"Obteniendo detalles y generando parquets (workers: {max_workers})...")
+        _log("INFO", "Obteniendo detalles y generando parquets (modo secuencial)...")
 
         batch_buffer = []
-        batch_buffer_lock = threading.Lock() if max_workers > 1 else None
         failed_count = 0
-        failed_lock = threading.Lock() if max_workers > 1 else None
         parquet_paths = []
         batch_num = 0
         total_saved = 0
@@ -375,61 +371,25 @@ def scrape_historico(params: SearchParams, max_workers: int = 3) -> list[Path]:
             )
             return parquet_path
 
-        if max_workers > 1:
-            # Modo paralelo con ThreadPool
-            def process_convocatoria(conv):
-                nonlocal batch_num, total_saved, failed_count
+        # Modo secuencial - procesar todas las convocatorias
+        for conv in tqdm(light_convocatorias, unit="conv"):
+            try:
+                result = fetch_convocatoria_detalle(conv["numero_convocatoria"], rate_limiter)
+                if result:
+                    batch_buffer.append(result)
 
-                try:
-                    result = fetch_convocatoria_detalle(conv["numero_convocatoria"], rate_limiter)
-                    if result:
-                        with batch_buffer_lock:
-                            batch_buffer.append(result)
-
-                            if len(batch_buffer) >= MAX_RECORDS_PER_PARQUET:
-                                parquet_path = save_batch(batch_buffer[:], batch_num)
-                                if parquet_path:
-                                    parquet_paths.append(parquet_path)
-                                    total_saved += len(batch_buffer)
-                                batch_buffer.clear()
-                                batch_num += 1
-                    else:
-                        with failed_lock:
-                            failed_count += 1
-                except Exception as e:
-                    _log("ERROR", f"Excepción: {e}")
-                    with failed_lock:
-                        failed_count += 1
-
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                futures = [
-                    executor.submit(process_convocatoria, conv) for conv in light_convocatorias
-                ]
-
-                with tqdm(total=len(light_convocatorias), unit="conv") as pbar:
-                    for future in as_completed(futures):
-                        future.result()
-                        pbar.update(1)
-        else:
-            # Modo secuencial (original)
-            for conv in tqdm(light_convocatorias, unit="conv"):
-                try:
-                    result = fetch_convocatoria_detalle(conv["numero_convocatoria"], rate_limiter)
-                    if result:
-                        batch_buffer.append(result)
-
-                        if len(batch_buffer) >= MAX_RECORDS_PER_PARQUET:
-                            parquet_path = save_batch(batch_buffer, batch_num)
-                            if parquet_path:
-                                parquet_paths.append(parquet_path)
-                                total_saved += len(batch_buffer)
-                            batch_buffer = []
-                            batch_num += 1
-                    else:
-                        failed_count += 1
-                except Exception as e:
-                    _log("ERROR", f"Excepción: {e}")
+                    if len(batch_buffer) >= MAX_RECORDS_PER_PARQUET:
+                        parquet_path = save_batch(batch_buffer, batch_num)
+                        if parquet_path:
+                            parquet_paths.append(parquet_path)
+                            total_saved += len(batch_buffer)
+                        batch_buffer = []
+                        batch_num += 1
+                else:
                     failed_count += 1
+            except Exception as e:
+                _log("ERROR", f"Excepción: {e}")
+                failed_count += 1
 
         if batch_buffer:
             parquet_path = save_batch(batch_buffer, batch_num)
@@ -478,7 +438,8 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
     total_new = 0
     total_duplicates = 0
     total_filtered = 0
-    rate_limiter = RateLimiter(max_requests=49, time_window=60)
+    # Rate limiter: endpoint de detalles tiene límite ~20 req/min
+    rate_limiter = RateLimiter(max_requests=20, time_window=60)
     subvencion_pattern = re.compile(r"subvenci[oó]n", re.IGNORECASE)
 
     _log("INFO", "Actualizando subvenciones diarias...")

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -574,7 +574,7 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
                 continue
 
             detailed_records = []
-            for conv in enumerate(new_convocatorias):
+            for conv in new_convocatorias:
                 # Convert back to string for API request
                 detail = fetch_convocatoria_detalle(str(conv["numero_convocatoria"]))
                 if detail:
@@ -725,7 +725,7 @@ def main():
         fecha_hasta = datetime.now().strftime("%d/%m/%Y")
 
     # fecha_desde = f"01/01/{ano_inicio}"
-    fecha_desde = f"19/04/2026"
+    fecha_desde = f"16/04/2026"
     _log("INFO", f"Fechas: {fecha_desde} - {fecha_hasta}")
     _log("INFO", f"Conjunto: {args.conjunto}")
 

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -173,25 +173,24 @@ def _extract_beneficiarios_ids(beneficiarios_array) -> list[int] | None:
     return ids if ids else None
 
 
-def _extract_nut_codes(sectores_array) -> list[str] | None:
+def _extract_nut_codes(regiones_array) -> list[str] | None:
     """
-    Extract NUT codes (geographic regions) from API array.
-    In API, this data incorrectly comes in 'sectores' field.
+    Extract NUT codes (geographic regions) from API regiones array.
 
     Args:
-        sectores_array: Array from API (e.g., [{"descripcion": "ES618 - Sevilla"}])
+        regiones_array: Array from API (e.g., [{"descripcion": "ES41 - CASTILLA Y LEON"}])
 
     Returns:
         List of NUT codes or None if empty
     """
-    if not sectores_array or not isinstance(sectores_array, list):
+    if not regiones_array or not isinstance(regiones_array, list):
         return None
 
-    if len(sectores_array) == 0:
+    if len(regiones_array) == 0:
         return None
 
     nut_codes = []
-    for item in sectores_array:
+    for item in regiones_array:
         if isinstance(item, dict):
             descripcion = item.get("descripcion", "").strip()
             # Extract NUT code (format: "ES618 - Sevilla" -> "ES618")
@@ -203,26 +202,25 @@ def _extract_nut_codes(sectores_array) -> list[str] | None:
     return nut_codes if nut_codes else None
 
 
-def _extract_sector_codes(regiones_array) -> list[str] | None:
+def _extract_sector_codes(sectores_array) -> list[str] | None:
     """
-    Extract sector CNAE codes (economic sectors) from API array.
-    In API, this data incorrectly comes in 'regiones' field.
+    Extract sector CNAE codes (economic sectors) from API sectores array.
     Normalizes decimal codes: '96.4' -> '9640', '96.18' -> '9618'
 
     Args:
-        regiones_array: Array from API (e.g., [{"codigo": "I", "descripcion": "HOSTELERÍA"}])
+        sectores_array: Array from API (e.g., [{"codigo": "I", "descripcion": "HOSTELERÍA"}])
 
     Returns:
         List of normalized sector codes or None if empty
     """
-    if not regiones_array or not isinstance(regiones_array, list):
+    if not sectores_array or not isinstance(sectores_array, list):
         return None
 
-    if len(regiones_array) == 0:
+    if len(sectores_array) == 0:
         return None
 
     sector_codes = []
-    for item in regiones_array:
+    for item in sectores_array:
         if isinstance(item, dict):
             codigo = item.get("codigo", "").strip()
             if codigo:
@@ -452,14 +450,14 @@ def fetch_convocatoria_detalle(
                 "mrr": data.get("mrr"),
                 "descripcion": data.get("descripcion"),
                 "descripcion_leng": data.get("descripcionLeng"),
-                # Note: API has bug - sectores/regiones are swapped, we correct it here
+                # Extract arrays
                 "tipos_beneficiarios": _extract_beneficiarios_ids(data.get("tiposBeneficiarios")),
                 "sectores": _extract_sector_codes(
-                    data.get("regiones")
-                ),  # Correct: extract CNAE from API 'regiones'
-                "regiones": _extract_nut_codes(
                     data.get("sectores")
-                ),  # Correct: extract NUT from API 'sectores'
+                ),  # Extract CNAE codes from API 'sectores'
+                "regiones": _extract_nut_codes(
+                    data.get("regiones")
+                ),  # Extract NUT codes from API 'regiones'
                 "descripcion_finalidad": data.get("descripcionFinalidad"),
                 "descripcion_bases_reguladoras": data.get("descripcionBasesReguladoras"),
                 "url_bases_reguladoras": data.get("urlBasesReguladoras"),
@@ -585,13 +583,6 @@ def scrape_historico(params: SearchParams) -> list[Path]:
             "documentos",
             "anuncios",
         ]
-        
-        # Array columns that need serialization for parquet
-        array_cols = [
-            "tipos_beneficiarios",
-            "sectores",
-            "regiones",
-        ]
 
         def save_batch(records, batch_number):
             """Save current batch to parquet and clear buffer."""
@@ -602,11 +593,6 @@ def scrape_historico(params: SearchParams) -> list[Path]:
 
             # Serialize JSONB columns
             for col in jsonb_cols:
-                if col in df.columns:
-                    df[col] = df[col].apply(lambda x: json.dumps(x) if x is not None else None)
-            
-            # Serialize array columns to JSON strings for parquet compatibility
-            for col in array_cols:
                 if col in df.columns:
                     df[col] = df[col].apply(lambda x: json.dumps(x) if x is not None else None)
 

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -646,14 +646,15 @@ def main():
     if len(partes) > 1:
         ano_fin = int(partes[1])
         if ano_fin == datetime.now().year:
-            fecha_hasta = datetime.now().strftime("%d/%m/%Y")
+            # fecha_hasta = datetime.now().strftime("%d/%m/%Y")
+            fecha_hasta = "18/04/2026"
         else:
             fecha_hasta = f"31/12/{ano_fin}"
     else:
         fecha_hasta = datetime.now().strftime("%d/%m/%Y")
 
-    fecha_desde = f"01/01/{ano_inicio}"
-
+    # fecha_desde = f"01/01/{ano_inicio}"
+    fecha_desde = f"16/04/2026"
     _log("INFO", f"Fechas: {fecha_desde} - {fecha_hasta}")
     _log("INFO", f"Conjunto: {args.conjunto}")
 

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -335,63 +335,82 @@ def scrape_historico(params: SearchParams) -> list[Path]:
 
         _log("INFO", f"{len(light_convocatorias):,} convocatorias obtenidas")
 
-        _log("INFO", "Obteniendo detalles de convocatorias...")
-        detailed_records = []
+        _log("INFO", f"Obteniendo detalles y generando parquets...")
+
+        batch_buffer = []
         failed_count = 0
-
-        for conv in tqdm(light_convocatorias, unit="conv"):
-            try:
-                result = fetch_convocatoria_detalle(conv["numero_convocatoria"], rate_limiter)
-                if result:
-                    detailed_records.append(result)
-                else:
-                    failed_count += 1
-            except Exception as e:
-                _log("ERROR", f"Excepción: {e}")
-                failed_count += 1
-
-        if failed_count > 0:
-            _log("WARN", f"{failed_count} convocatorias fallaron")
-
-        if not detailed_records:
-            raise ValueError("No se obtuvieron registros detallados")
-
-        _log("INFO", f"Generando parquets (máx {MAX_RECORDS_PER_PARQUET:,} por archivo)...")
         parquet_paths = []
+        batch_num = 0
+        total_saved = 0
 
-        for batch_idx in range(0, len(detailed_records), MAX_RECORDS_PER_PARQUET):
-            batch_records = detailed_records[batch_idx : batch_idx + MAX_RECORDS_PER_PARQUET]
-            df = pd.DataFrame(batch_records)
+        jsonb_cols = [
+            "instrumentos",
+            "tipos_beneficiarios",
+            "sectores",
+            "regiones",
+            "fondos",
+            "reglamento",
+            "objetivos",
+            "sectores_productos",
+            "documentos",
+            "anuncios",
+        ]
 
-            # Serialize JSONB columns
-            jsonb_cols = [
-                "instrumentos",
-                "tipos_beneficiarios",
-                "sectores",
-                "regiones",
-                "fondos",
-                "reglamento",
-                "objetivos",
-                "sectores_productos",
-                "documentos",
-                "anuncios",
-            ]
+        def save_batch(records, batch_number):
+            """Save current batch to parquet and clear buffer."""
+            if not records:
+                return None
+
+            df = pd.DataFrame(records)
+
             for col in jsonb_cols:
                 if col in df.columns:
                     df[col] = df[col].apply(lambda x: json.dumps(x) if x is not None else None)
 
-            batch_num = batch_idx // MAX_RECORDS_PER_PARQUET
-            parquet_filename = f"_part_subvenciones_{batch_num:04d}.parquet"
+            parquet_filename = f"_part_subvenciones_{batch_number:04d}.parquet"
             parquet_path = OUTPUT_DIR / parquet_filename
 
             df.to_parquet(parquet_path, engine="pyarrow", index=False)
-            parquet_paths.append(parquet_path)
 
             size_mb = parquet_path.stat().st_size / (1024 * 1024)
             _log(
                 "INFO",
                 f"{parquet_path.name} ({len(df):,} registros guardados, {size_mb:.1f} MB)",
             )
+            return parquet_path
+
+        for conv in tqdm(light_convocatorias, unit="conv"):
+            try:
+                result = fetch_convocatoria_detalle(conv["numero_convocatoria"], rate_limiter)
+                if result:
+                    batch_buffer.append(result)
+
+                    if len(batch_buffer) >= MAX_RECORDS_PER_PARQUET:
+                        parquet_path = save_batch(batch_buffer, batch_num)
+                        if parquet_path:
+                            parquet_paths.append(parquet_path)
+                            total_saved += len(batch_buffer)
+                        batch_buffer = []
+                        batch_num += 1
+                else:
+                    failed_count += 1
+            except Exception as e:
+                _log("ERROR", f"Excepción: {e}")
+                failed_count += 1
+
+        if batch_buffer:
+            parquet_path = save_batch(batch_buffer, batch_num)
+            if parquet_path:
+                parquet_paths.append(parquet_path)
+                total_saved += len(batch_buffer)
+
+        if failed_count > 0:
+            _log("WARN", f"{failed_count} convocatorias fallaron")
+
+        if not parquet_paths:
+            raise ValueError("No se generaron parquets (sin registros válidos)")
+
+        _log("INFO", f"{total_saved:,} registros guardados en {len(parquet_paths)} parquets")
 
         return parquet_paths
 

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -46,6 +46,257 @@ OUTPUT_DIR = _tmp_base / "output"
 _api_delay_seconds = 0  # Start with no delay, adjust only if rate limited
 _api_delay_lock = threading.Lock()  # Thread-safe access to delay variable
 
+# Cache para mapeo de instrumentos (cargado desde BD)
+_instrumentos_map_cache = None
+_instrumentos_map_lock = threading.Lock()
+
+# Cache para mapeo de beneficiarios (cargado desde BD)
+_beneficiarios_map_cache = None
+_beneficiarios_map_lock = threading.Lock()
+
+
+def _load_instrumentos_map() -> dict[str, int]:
+    """
+    Load instrumentos mapping from database.
+    Cached globally to avoid repeated queries.
+
+    Returns:
+        Dictionary mapping descripcion -> id
+    """
+    global _instrumentos_map_cache
+
+    with _instrumentos_map_lock:
+        if _instrumentos_map_cache is not None:
+            return _instrumentos_map_cache
+
+        try:
+            conn = psycopg2.connect(get_database_url())
+            cur = conn.cursor()
+            cur.execute("SELECT id, descripcion FROM dim.instrumentos_subvenciones")
+            rows = cur.fetchall()
+            cur.close()
+            conn.close()
+
+            # Create mapping: descripcion (stripped) -> id
+            _instrumentos_map_cache = {row[1].strip(): row[0] for row in rows}
+            _log("INFO", f"Cargados {len(_instrumentos_map_cache)} instrumentos desde BD")
+            return _instrumentos_map_cache
+
+        except Exception as e:
+            _log("ERROR", f"Error cargando instrumentos desde BD: {e}")
+            return {}
+
+
+def _load_beneficiarios_map() -> dict[str, int]:
+    """
+    Load beneficiarios mapping from database.
+    Cached globally to avoid repeated queries.
+
+    Returns:
+        Dictionary mapping descripcion -> id
+    """
+    global _beneficiarios_map_cache
+
+    with _beneficiarios_map_lock:
+        if _beneficiarios_map_cache is not None:
+            return _beneficiarios_map_cache
+
+        try:
+            conn = psycopg2.connect(get_database_url())
+            cur = conn.cursor()
+            cur.execute("SELECT id, descripcion FROM dim.beneficiarios_subvenciones")
+            rows = cur.fetchall()
+            cur.close()
+            conn.close()
+
+            # Create mapping: descripcion (stripped) -> id
+            _beneficiarios_map_cache = {row[1].strip(): row[0] for row in rows}
+            _log("INFO", f"Cargados {len(_beneficiarios_map_cache)} beneficiarios desde BD")
+            return _beneficiarios_map_cache
+
+        except Exception as e:
+            _log("ERROR", f"Error cargando beneficiarios desde BD: {e}")
+            return {}
+
+
+def _extract_instrumento_id(instrumentos_array) -> int | None:
+    """
+    Extract instrumento_id from API instrumentos array.
+    Takes the first element's descripcion and maps it to ID from database.
+
+    Args:
+        instrumentos_array: Array from API (e.g., [{"descripcion": "..."}])
+
+    Returns:
+        Integer ID or None if not found
+    """
+    if not instrumentos_array or not isinstance(instrumentos_array, list):
+        return None
+
+    if len(instrumentos_array) == 0:
+        return None
+
+    first_instrumento = instrumentos_array[0]
+    if not isinstance(first_instrumento, dict):
+        return None
+
+    descripcion = first_instrumento.get("descripcion", "").strip()
+    instrumentos_map = _load_instrumentos_map()
+    return instrumentos_map.get(descripcion)
+
+
+def _extract_beneficiarios_ids(beneficiarios_array) -> list[int] | None:
+    """
+    Extract beneficiarios IDs from API tipos_beneficiarios array.
+    Maps all descriptions to their IDs.
+
+    Args:
+        beneficiarios_array: Array from API (e.g., [{"descripcion": "..."}])
+
+    Returns:
+        List of integer IDs or None if empty
+    """
+    if not beneficiarios_array or not isinstance(beneficiarios_array, list):
+        return None
+
+    if len(beneficiarios_array) == 0:
+        return None
+
+    beneficiarios_map = _load_beneficiarios_map()
+    ids = []
+
+    for item in beneficiarios_array:
+        if isinstance(item, dict):
+            descripcion = item.get("descripcion", "").strip()
+            beneficiario_id = beneficiarios_map.get(descripcion)
+            if beneficiario_id:
+                ids.append(beneficiario_id)
+
+    return ids if ids else None
+
+
+def _extract_nut_codes(sectores_array) -> list[str] | None:
+    """
+    Extract NUT codes (geographic regions) from API array.
+    In API, this data incorrectly comes in 'sectores' field.
+
+    Args:
+        sectores_array: Array from API (e.g., [{"descripcion": "ES618 - Sevilla"}])
+
+    Returns:
+        List of NUT codes or None if empty
+    """
+    if not sectores_array or not isinstance(sectores_array, list):
+        return None
+
+    if len(sectores_array) == 0:
+        return None
+
+    nut_codes = []
+    for item in sectores_array:
+        if isinstance(item, dict):
+            descripcion = item.get("descripcion", "").strip()
+            # Extract NUT code (format: "ES618 - Sevilla" -> "ES618")
+            if " - " in descripcion:
+                nut_code = descripcion.split(" - ")[0].strip()
+                if nut_code:
+                    nut_codes.append(nut_code)
+
+    return nut_codes if nut_codes else None
+
+
+def _extract_sector_codes(regiones_array) -> list[str] | None:
+    """
+    Extract sector CNAE codes (economic sectors) from API array.
+    In API, this data incorrectly comes in 'regiones' field.
+    Normalizes decimal codes: '96.4' -> '9640', '96.18' -> '9618'
+
+    Args:
+        regiones_array: Array from API (e.g., [{"codigo": "I", "descripcion": "HOSTELERÍA"}])
+
+    Returns:
+        List of normalized sector codes or None if empty
+    """
+    if not regiones_array or not isinstance(regiones_array, list):
+        return None
+
+    if len(regiones_array) == 0:
+        return None
+
+    sector_codes = []
+    for item in regiones_array:
+        if isinstance(item, dict):
+            codigo = item.get("codigo", "").strip()
+            if codigo:
+                # Normalizar códigos con decimal (ej: '96.4' -> '9640', '96.18' -> '9618')
+                if "." in codigo:
+                    codigo_sin_punto = codigo.replace(".", "")
+                    # Si después de quitar el punto tiene 3 dígitos, añadir un 0 al final
+                    if len(codigo_sin_punto) == 3:
+                        codigo = codigo_sin_punto + "0"
+                    else:
+                        codigo = codigo_sin_punto
+
+                sector_codes.append(codigo)
+
+    return sector_codes if sector_codes else None
+
+
+def _extract_reglamento_descripcion(reglamento_obj) -> str | None:
+    """
+    Extract descripcion from reglamento object.
+
+    Args:
+        reglamento_obj: Object from API (e.g., {"orden": null, "descripcion": "..."})
+
+    Returns:
+        String with descripcion or None
+    """
+    if not reglamento_obj or not isinstance(reglamento_obj, dict):
+        return None
+
+    descripcion = reglamento_obj.get("descripcion", "").strip()
+    return descripcion if descripcion else None
+
+
+def _extract_objetivos_descripcion(objetivos_array) -> str | None:
+    """
+    Extract descripcion from first objetivo in array.
+
+    Args:
+        objetivos_array: Array from API (e.g., [{"descripcion": "..."}])
+
+    Returns:
+        String with first descripcion or None
+    """
+    if not objetivos_array or not isinstance(objetivos_array, list):
+        return None
+
+    if len(objetivos_array) == 0:
+        return None
+
+    first_objetivo = objetivos_array[0]
+    if isinstance(first_objetivo, dict):
+        descripcion = first_objetivo.get("descripcion", "").strip()
+        return descripcion if descripcion else None
+
+    return None
+
+
+def _normalize_empty_jsonb(value):
+    """
+    Convert empty arrays [] to None for cleaner database storage.
+
+    Args:
+        value: JSONB value (typically array or dict)
+
+    Returns:
+        None if empty array, otherwise the original value
+    """
+    if isinstance(value, list) and len(value) == 0:
+        return None
+    return value
+
 
 def _ensure_output_dir():
     """Ensure output directory exists."""
@@ -197,17 +448,20 @@ def fetch_convocatoria_detalle(
                 "nivel3": nivel3,
                 "sede_electronica": data.get("sedeElectronica"),
                 "fecha_recepcion": data.get("fechaRecepcion"),
-                "instrumentos": _convert_to_json_serializable(data.get("instrumentos")),
+                "instrumento_id": _extract_instrumento_id(data.get("instrumentos")),
                 "tipo_convocatoria": data.get("tipoConvocatoria"),
                 "presupuesto_total": data.get("presupuestoTotal"),
                 "mrr": data.get("mrr"),
                 "descripcion": data.get("descripcion"),
                 "descripcion_leng": data.get("descripcionLeng"),
-                "tipos_beneficiarios": _convert_to_json_serializable(
-                    data.get("tiposBeneficiarios")
-                ),
-                "sectores": _convert_to_json_serializable(data.get("sectores")),
-                "regiones": _convert_to_json_serializable(data.get("regiones")),
+                # Note: API has bug - sectores/regiones are swapped, we correct it here
+                "tipos_beneficiarios": _extract_beneficiarios_ids(data.get("tiposBeneficiarios")),
+                "sectores": _extract_sector_codes(
+                    data.get("regiones")
+                ),  # Correct: extract CNAE from API 'regiones'
+                "regiones": _extract_nut_codes(
+                    data.get("sectores")
+                ),  # Correct: extract NUT from API 'sectores'
                 "descripcion_finalidad": data.get("descripcionFinalidad"),
                 "descripcion_bases_reguladoras": data.get("descripcionBasesReguladoras"),
                 "url_bases_reguladoras": data.get("urlBasesReguladoras"),
@@ -219,12 +473,18 @@ def fetch_convocatoria_detalle(
                 "text_fin": data.get("textFin"),
                 "ayuda_estado": data.get("ayudaEstado"),
                 "url_ayuda_estado": data.get("urlAyudaEstado"),
-                "fondos": _convert_to_json_serializable(data.get("fondos")),
-                "reglamento": _convert_to_json_serializable(data.get("reglamento")),
-                "objetivos": _convert_to_json_serializable(data.get("objetivos")),
-                "sectores_productos": _convert_to_json_serializable(data.get("sectoresProductos")),
-                "documentos": _convert_to_json_serializable(data.get("documentos")),
-                "anuncios": _convert_to_json_serializable(data.get("anuncios")),
+                "fondos": _normalize_empty_jsonb(_convert_to_json_serializable(data.get("fondos"))),
+                "reglamento": _extract_reglamento_descripcion(data.get("reglamento")),
+                "objetivos": _extract_objetivos_descripcion(data.get("objetivos")),
+                "sectores_productos": _normalize_empty_jsonb(
+                    _convert_to_json_serializable(data.get("sectoresProductos"))
+                ),
+                "documentos": _normalize_empty_jsonb(
+                    _convert_to_json_serializable(data.get("documentos"))
+                ),
+                "anuncios": _normalize_empty_jsonb(
+                    _convert_to_json_serializable(data.get("anuncios"))
+                ),
             }
 
             return record
@@ -322,14 +582,9 @@ def scrape_historico(params: SearchParams) -> list[Path]:
         total_saved = [0]  # Shared between threads
         fetching_done = threading.Event()
 
+        # Only these columns need JSON serialization now
         jsonb_cols = [
-            "instrumentos",
-            "tipos_beneficiarios",
-            "sectores",
-            "regiones",
             "fondos",
-            "reglamento",
-            "objetivos",
             "sectores_productos",
             "documentos",
             "anuncios",
@@ -342,6 +597,7 @@ def scrape_historico(params: SearchParams) -> list[Path]:
 
             df = pd.DataFrame(records)
 
+            # Serialize JSONB columns
             for col in jsonb_cols:
                 if col in df.columns:
                     df[col] = df[col].apply(lambda x: json.dumps(x) if x is not None else None)
@@ -584,21 +840,16 @@ def scrape_diario(params: SearchParams) -> dict[str, int]:
 
         _log("INFO", "Guardando en BD...")
         records_to_insert = []
+        # Only these columns need JSON serialization now
         jsonb_cols = [
-            "instrumentos",
-            "tipos_beneficiarios",
-            "sectores",
-            "regiones",
             "fondos",
-            "reglamento",
-            "objetivos",
             "sectores_productos",
             "documentos",
             "anuncios",
         ]
 
         for record in detailed_records:
-            # Serialize JSONB columns
+            # Serialize JSONB columns only
             for col in jsonb_cols:
                 if record.get(col) is not None:
                     record[col] = json.dumps(record[col])
@@ -611,15 +862,15 @@ def scrape_diario(params: SearchParams) -> dict[str, int]:
                     record.get("nivel3"),
                     record.get("sede_electronica"),
                     record.get("fecha_recepcion"),
-                    record.get("instrumentos"),
+                    record.get("instrumento_id"),
                     record.get("tipo_convocatoria"),
                     record.get("presupuesto_total"),
                     record.get("mrr"),
                     record.get("descripcion"),
                     record.get("descripcion_leng"),
-                    record.get("tipos_beneficiarios"),
-                    record.get("regiones"),
-                    record.get("sectores"),
+                    record.get("tipos_beneficiarios"),  # Array of SMALLINT
+                    record.get("sectores"),  # Array of VARCHAR (CNAE codes)
+                    record.get("regiones"),  # Array of VARCHAR (NUT codes)
                     record.get("descripcion_finalidad"),
                     record.get("descripcion_bases_reguladoras"),
                     record.get("url_bases_reguladoras"),
@@ -643,7 +894,7 @@ def scrape_diario(params: SearchParams) -> dict[str, int]:
         insert_sql = """
             INSERT INTO l0.nacional_subvenciones 
             (id, nivel1, nivel2, nivel3, sede_electronica, fecha_recepcion,
-             instrumentos, tipo_convocatoria, presupuesto_total, mrr, descripcion, descripcion_leng,
+             instrumento_id, tipo_convocatoria, presupuesto_total, mrr, descripcion, descripcion_leng,
              tipos_beneficiarios, sectores, regiones, descripcion_finalidad, descripcion_bases_reguladoras,
              url_bases_reguladoras, se_publica_diario_oficial, abierto, fecha_inicio_solicitud,
              fecha_fin_solicitud, text_inicio, text_fin, ayuda_estado, url_ayuda_estado,
@@ -704,13 +955,15 @@ def main():
     if len(partes) > 1:
         ano_fin = int(partes[1])
         if ano_fin == datetime.now().year:
-            fecha_hasta = datetime.now().strftime("%d/%m/%Y")
+            # fecha_hasta = datetime.now().strftime("%d/%m/%Y")
+            fecha_hasta = "21/04/2026"
         else:
             fecha_hasta = f"31/12/{ano_fin}"
     else:
         fecha_hasta = datetime.now().strftime("%d/%m/%Y")
 
-    fecha_desde = f"01/01/{ano_inicio}"
+    # fecha_desde = f"01/01/{ano_inicio}"
+    fecha_desde = "17/04/2026"
     _log("INFO", f"Fechas: {fecha_desde} - {fecha_hasta}")
     _log("INFO", f"Conjunto: {args.conjunto}")
 

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -254,7 +254,7 @@ def fetch_convocatoria_detalle(
         return None
 
 
-def scrape_historico(params: SearchParams, max_workers: int = 1) -> list[Path]:
+def scrape_historico(params: SearchParams, max_workers: int = 3) -> list[Path]:
     """
     Scrape historical grants data and save to Parquet files.
     This is for initial bulk load - generates Parquet files for etl/ingest_l0.py to process.
@@ -263,7 +263,7 @@ def scrape_historico(params: SearchParams, max_workers: int = 1) -> list[Path]:
 
     Args:
         params: SearchParams with date range (fechaDesde required, fechaHasta defaults to today)
-        max_workers: Number of threads for parallel fetching (default: 1 = sequential)
+        max_workers: Number of threads for parallel fetching (default: 3)
 
     Returns:
         List of paths to generated Parquet files
@@ -688,12 +688,6 @@ def main():
         action="store_true",
         help="Solo descargar/generar Parquet, no cargar en BD",
     )
-    parser.add_argument(
-        "--workers",
-        type=int,
-        default=1,
-        help="Número de workers para ThreadPool (default: 1 = secuencial)",
-    )
 
     args = parser.parse_args()
 
@@ -724,10 +718,7 @@ def main():
             fechaHasta=fecha_hasta,
         )
 
-        workers = getattr(args, "workers", 1)
-        _log("INFO", f"Usando {workers} worker(s) para fetching")
-
-        parquet_paths = scrape_historico(params, max_workers=workers)
+        parquet_paths = scrape_historico(params)
         if args.solo_descargar:
             _log("INFO", "(--solo-descargar: no se cargará en BD)")
             _log("INFO", f"Archivos generados: {len(parquet_paths)}")

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -228,7 +228,6 @@ def fetch_convocatoria_detalle(
                 "sectores_productos": _convert_to_json_serializable(data.get("sectoresProductos")),
                 "documentos": _convert_to_json_serializable(data.get("documentos")),
                 "anuncios": _convert_to_json_serializable(data.get("anuncios")),
-                "advertencia": data.get("advertencia"),
             }
 
             return record
@@ -313,12 +312,15 @@ def scrape_historico(params: SearchParams) -> list[Path]:
                     break
 
                 for item in content:
-                    light_convocatorias.append(
-                        {
-                            "id": item.get("id"),
-                            "numero_convocatoria": item.get("numeroConvocatoria"),
-                        }
-                    )
+                    # Convert numeroConvocatoria to int for consistent type handling
+                    numero_conv = item.get("numeroConvocatoria")
+                    if numero_conv:
+                        light_convocatorias.append(
+                            {
+                                "id": item.get("id"),
+                                "numero_convocatoria": int(numero_conv),
+                            }
+                        )
 
                 page += 1
                 pbar.update(1)
@@ -365,12 +367,6 @@ def scrape_historico(params: SearchParams) -> list[Path]:
             parquet_path = OUTPUT_DIR / parquet_filename
 
             df.to_parquet(parquet_path, engine="pyarrow", index=False)
-
-            size_mb = parquet_path.stat().st_size / (1024 * 1024)
-            _log(
-                "INFO",
-                f"{parquet_path.name} ({len(df):,} registros guardados, {size_mb:.1f} MB)",
-            )
             return parquet_path
 
         def fetcher():
@@ -378,7 +374,8 @@ def scrape_historico(params: SearchParams) -> list[Path]:
             nonlocal failed_count
             for conv in tqdm(light_convocatorias, unit="conv", desc="Fetch+Preproc"):
                 try:
-                    result = fetch_convocatoria_detalle(conv["numero_convocatoria"])
+                    # Convert back to string for API request
+                    result = fetch_convocatoria_detalle(str(conv["numero_convocatoria"]))
                     if result:
                         buffer.put(result)
                     else:
@@ -520,12 +517,15 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
                 if not subvencion_pattern.search(descripcion):
                     page_filtered += 1
                     continue
-                light_convocatorias.append(
-                    {
-                        "id": item.get("id"),
-                        "numero_convocatoria": item.get("numeroConvocatoria"),
-                    }
-                )
+                # Convert numeroConvocatoria to int for consistent type comparison
+                numero_conv = item.get("numeroConvocatoria")
+                if numero_conv:
+                    light_convocatorias.append(
+                        {
+                            "id": item.get("id"),
+                            "numero_convocatoria": int(numero_conv),
+                        }
+                    )
             total_filtered += page_filtered
 
             if not light_convocatorias:
@@ -536,12 +536,14 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
             with conn.cursor() as cur:
                 cur.execute(
                     "SELECT id FROM l0.nacional_subvenciones WHERE id = ANY(%s)",
-                    ([conv["id"] for conv in light_convocatorias],),
+                    ([conv["numero_convocatoria"] for conv in light_convocatorias],),
                 )
                 existing_ids = {row[0] for row in cur.fetchall()}
 
                 new_convocatorias = [
-                    conv for conv in light_convocatorias if conv["id"] not in existing_ids
+                    conv
+                    for conv in light_convocatorias
+                    if conv["numero_convocatoria"] not in existing_ids
                 ]
                 page_dups = len(existing_ids)
                 total_duplicates += page_dups
@@ -557,7 +559,8 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
                 detailed_records = []
                 _log("INFO", "Obteniendo detalles de convocatorias...")
                 for conv in tqdm(new_convocatorias, unit="conv"):
-                    detail = fetch_convocatoria_detalle(conv["numero_convocatoria"])
+                    # Convert back to string for API request
+                    detail = fetch_convocatoria_detalle(str(conv["numero_convocatoria"]))
                     if detail:
                         detailed_records.append(detail)
 
@@ -573,8 +576,8 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
                      tipos_beneficiarios, sectores, regiones, descripcion_finalidad, descripcion_bases_reguladoras,
                      url_bases_reguladoras, se_publica_diario_oficial, abierto, fecha_inicio_solicitud,
                      fecha_fin_solicitud, text_inicio, text_fin, ayuda_estado, url_ayuda_estado,
-                     fondos, reglamento, objetivos, sectores_productos, documentos, anuncios, advertencia)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                     fondos, reglamento, objetivos, sectores_productos, documentos, anuncios)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     ON CONFLICT (id) DO NOTHING
                 """
 
@@ -632,7 +635,6 @@ def scrape_diario(params: LatestParams) -> dict[str, int]:
                             record.get("sectores_productos"),
                             record.get("documentos"),
                             record.get("anuncios"),
-                            record.get("advertencia"),
                         )
                     )
 

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -79,7 +79,6 @@ def _load_instrumentos_map() -> dict[str, int]:
 
             # Create mapping: descripcion (stripped) -> id
             _instrumentos_map_cache = {row[1].strip(): row[0] for row in rows}
-            _log("INFO", f"Cargados {len(_instrumentos_map_cache)} instrumentos desde BD")
             return _instrumentos_map_cache
 
         except Exception as e:
@@ -111,7 +110,6 @@ def _load_beneficiarios_map() -> dict[str, int]:
 
             # Create mapping: descripcion (stripped) -> id
             _beneficiarios_map_cache = {row[1].strip(): row[0] for row in rows}
-            _log("INFO", f"Cargados {len(_beneficiarios_map_cache)} beneficiarios desde BD")
             return _beneficiarios_map_cache
 
         except Exception as e:
@@ -964,8 +962,6 @@ def main():
 
     # fecha_desde = f"01/01/{ano_inicio}"
     fecha_desde = "17/04/2026"
-    _log("INFO", f"Fechas: {fecha_desde} - {fecha_hasta}")
-    _log("INFO", f"Conjunto: {args.conjunto}")
 
     try:
         params = SearchParams(
@@ -973,7 +969,7 @@ def main():
             pageSize=10000,
             fechaDesde=fecha_desde,
             fechaHasta=fecha_hasta,
-            direccion="asc",  # For historical scraping, use ascending order
+            direccion="asc",
         )
 
         parquet_paths = scrape_historico(params)

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -54,6 +54,10 @@ _instrumentos_map_lock = threading.Lock()
 _beneficiarios_map_cache = None
 _beneficiarios_map_lock = threading.Lock()
 
+# Cache para mapeo de política de gastos (cargado desde BD)
+_politica_gastos_map_cache = None
+_politica_gastos_map_lock = threading.Lock()
+
 
 def _load_instrumentos_map() -> dict[str, int]:
     """
@@ -115,6 +119,54 @@ def _load_beneficiarios_map() -> dict[str, int]:
         except Exception as e:
             _log("ERROR", f"Error cargando beneficiarios desde BD: {e}")
             return {}
+
+
+def _load_politica_gastos_map() -> dict[str, int]:
+    """
+    Load politica_gastos mapping from database.
+    Cached globally to avoid repeated queries.
+
+    Returns:
+        Dictionary mapping descripcion -> id
+    """
+    global _politica_gastos_map_cache
+
+    with _politica_gastos_map_lock:
+        if _politica_gastos_map_cache is not None:
+            return _politica_gastos_map_cache
+
+        try:
+            conn = psycopg2.connect(get_database_url())
+            cur = conn.cursor()
+            cur.execute("SELECT id, descripcion FROM dim.politica_gastos")
+            rows = cur.fetchall()
+            cur.close()
+            conn.close()
+
+            # Create mapping: descripcion (stripped) -> id
+            _politica_gastos_map_cache = {row[1].strip(): row[0] for row in rows}
+            return _politica_gastos_map_cache
+
+        except Exception as e:
+            _log("ERROR", f"Error cargando politica_gastos desde BD: {e}")
+            return {}
+
+
+def _extract_politica_gastos_id(descripcion_finalidad) -> int | None:
+    """
+    Map descripcionFinalidad text from API to ID in dim.politica_gastos.
+
+    Args:
+        descripcion_finalidad: Text string from API (e.g., "JUSTICIA")
+
+    Returns:
+        Integer ID or None if not found
+    """
+    if not descripcion_finalidad or not isinstance(descripcion_finalidad, str):
+        return None
+
+    politica_gastos_map = _load_politica_gastos_map()
+    return politica_gastos_map.get(descripcion_finalidad.strip())
 
 
 def _extract_instrumento_id(instrumentos_array) -> int | None:
@@ -476,7 +528,7 @@ def fetch_convocatoria_detalle(
                 "regiones": _extract_nut_codes(
                     data.get("regiones")
                 ),  # Extract NUT codes from API 'regiones'
-                "descripcion_finalidad": data.get("descripcionFinalidad"),
+                "politica_gastos": _extract_politica_gastos_id(data.get("descripcionFinalidad")),
                 "descripcion_bases_reguladoras": data.get("descripcionBasesReguladoras"),
                 "url_bases_reguladoras": data.get("urlBasesReguladoras"),
                 "resumen_bases_reguladoras": None,
@@ -896,7 +948,7 @@ def scrape_diario(params: SearchParams) -> dict[str, int]:
                     record.get("tipos_beneficiarios"),  # Array of SMALLINT
                     record.get("sectores"),  # Array of VARCHAR (CNAE codes)
                     record.get("regiones"),  # Array of VARCHAR (NUT codes)
-                    record.get("descripcion_finalidad"),
+                    record.get("politica_gastos"),
                     record.get("descripcion_bases_reguladoras"),
                     record.get("url_bases_reguladoras"),
                     record.get("resumen_bases_reguladoras"),
@@ -919,7 +971,7 @@ def scrape_diario(params: SearchParams) -> dict[str, int]:
             INSERT INTO l0.nacional_subvenciones 
             (id, nivel1, nivel2, nivel3, sede_electronica, fecha_recepcion,
              instrumento_id, tipo_convocatoria, presupuesto_total, mrr, descripcion, descripcion_leng,
-             tipos_beneficiarios, sectores, regiones, descripcion_finalidad, descripcion_bases_reguladoras,
+             tipos_beneficiarios, sectores, regiones, politica_gastos, descripcion_bases_reguladoras,
              url_bases_reguladoras, resumen_bases_reguladoras, se_publica_diario_oficial, abierto, fecha_inicio_solicitud,
              fecha_fin_solicitud, ayuda_estado, url_ayuda_estado,
              fondos, reglamento, objetivos, sectores_productos, documentos, anuncios)

--- a/nacional/subvenciones.py
+++ b/nacional/subvenciones.py
@@ -358,7 +358,7 @@ def scrape_historico(params: SearchParams) -> list[Path]:
             for conv in tqdm(light_convocatorias, unit="conv"):
                 try:
                     # Convert id to string for API request
-                    result = fetch_convocatoria_detalle(str(numero_conv))
+                    result = fetch_convocatoria_detalle(str(conv["id"]))
                     if result:
                         buffer.put(result)
                     else:

--- a/schemas/012_nacional_subvenciones.sql
+++ b/schemas/012_nacional_subvenciones.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS l0.nacional_subvenciones (
   sede_electronica TEXT,
   fecha_recepcion DATE,
   -- Instrumentos y tipo
-  instrumento_id SMALLINT REFERENCES dim.instrumentos_subvenciones(id),
+  instrumento_id SMALLINT,
   tipo_convocatoria TEXT,
   presupuesto_total NUMERIC,
   mrr BOOLEAN,

--- a/schemas/012_nacional_subvenciones.sql
+++ b/schemas/012_nacional_subvenciones.sql
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS l0.nacional_subvenciones (
   descripcion_finalidad TEXT,
   descripcion_bases_reguladoras TEXT,
   url_bases_reguladoras TEXT,
+  resumen_bases_reguladoras TEXT,
   -- Publicación y estado
   se_publica_diario_oficial BOOLEAN,
   abierto BOOLEAN,

--- a/schemas/012_nacional_subvenciones.sql
+++ b/schemas/012_nacional_subvenciones.sql
@@ -6,7 +6,6 @@ CREATE TABLE IF NOT EXISTS l0.nacional_subvenciones (
   nivel3 TEXT,
   -- Información básica
   sede_electronica TEXT,
-  codigo_bdns TEXT,
   fecha_recepcion DATE,
   -- Instrumentos y tipo
   instrumentos JSONB,

--- a/schemas/012_nacional_subvenciones.sql
+++ b/schemas/012_nacional_subvenciones.sql
@@ -42,7 +42,5 @@ CREATE TABLE IF NOT EXISTS l0.nacional_subvenciones (
   sectores_productos JSONB,
   -- Documentos y anuncios
   documentos JSONB,
-  anuncios JSONB,
-  -- Advertencia
-  advertencia TEXT
+  anuncios JSONB
 );

--- a/schemas/012_nacional_subvenciones.sql
+++ b/schemas/012_nacional_subvenciones.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS l0.nacional_subvenciones (
   sectores VARCHAR(10)[], -- Array de códigos CNAE/NACE (referencia: dim.cnae_dim.codigo)
   regiones VARCHAR(10)[], -- Array de códigos NUT (dim.nuts_spain.geocode),
   -- Finalidad y bases reguladoras
-  descripcion_finalidad TEXT,
+  politica_gastos SMALLINT, -- ID de dim.politica_gastos
   descripcion_bases_reguladoras TEXT,
   url_bases_reguladoras TEXT,
   resumen_bases_reguladoras TEXT,

--- a/schemas/012_nacional_subvenciones.sql
+++ b/schemas/012_nacional_subvenciones.sql
@@ -8,16 +8,16 @@ CREATE TABLE IF NOT EXISTS l0.nacional_subvenciones (
   sede_electronica TEXT,
   fecha_recepcion DATE,
   -- Instrumentos y tipo
-  instrumentos JSONB,
+  instrumento_id SMALLINT REFERENCES dim.instrumentos_subvenciones(id),
   tipo_convocatoria TEXT,
   presupuesto_total NUMERIC,
   mrr BOOLEAN,
   descripcion TEXT,
   descripcion_leng TEXT,
   -- Beneficiarios y sectores
-  tipos_beneficiarios JSONB,
-  sectores JSONB,
-  regiones JSONB,
+  tipos_beneficiarios SMALLINT[], -- Array de IDs de dim.beneficiarios_subvenciones
+  sectores VARCHAR(10)[], -- Array de códigos CNAE/NACE (referencia: dim.cnae_dim.codigo)
+  regiones VARCHAR(10)[], -- Array de códigos NUT (dim.nuts_spain.geocode),
   -- Finalidad y bases reguladoras
   descripcion_finalidad TEXT,
   descripcion_bases_reguladoras TEXT,
@@ -35,11 +35,25 @@ CREATE TABLE IF NOT EXISTS l0.nacional_subvenciones (
   url_ayuda_estado TEXT,
   -- Fondos y reglamento
   fondos JSONB,
-  reglamento JSONB,
+  reglamento TEXT, -- Solo descripción del reglamento
   -- Objetivos y sectores productos
-  objetivos JSONB,
+  objetivos TEXT, -- Solo descripción del primer objetivo
   sectores_productos JSONB,
   -- Documentos y anuncios
   documentos JSONB,
   anuncios JSONB
 );
+
+-- Índice para optimizar filtrado por instrumento (campo usado frecuentemente)
+CREATE INDEX IF NOT EXISTS idx_subvenciones_instrumento 
+ON l0.nacional_subvenciones(instrumento_id);
+
+-- Índices adicionales para arrays (optimización de búsquedas con operadores @>, &&, etc.)
+CREATE INDEX IF NOT EXISTS idx_subvenciones_beneficiarios 
+ON l0.nacional_subvenciones USING GIN(tipos_beneficiarios);
+
+CREATE INDEX IF NOT EXISTS idx_subvenciones_sectores 
+ON l0.nacional_subvenciones USING GIN(sectores);
+
+CREATE INDEX IF NOT EXISTS idx_subvenciones_regiones 
+ON l0.nacional_subvenciones USING GIN(regiones);

--- a/schemas/012_nacional_subvenciones.sql
+++ b/schemas/012_nacional_subvenciones.sql
@@ -28,8 +28,6 @@ CREATE TABLE IF NOT EXISTS l0.nacional_subvenciones (
   -- Fechas de solicitud
   fecha_inicio_solicitud DATE,
   fecha_fin_solicitud DATE,
-  text_inicio TEXT,
-  text_fin TEXT,
   -- Ayuda de estado
   ayuda_estado TEXT,
   url_ayuda_estado TEXT,

--- a/schemas/012_nacional_subvenciones.sql
+++ b/schemas/012_nacional_subvenciones.sql
@@ -1,12 +1,48 @@
 CREATE TABLE IF NOT EXISTS l0.nacional_subvenciones (
-  id INTEGER PRIMARY KEY,
-  numero_convocatoria VARCHAR(255) NOT NULL,
+  id BIGINT PRIMARY KEY,
+  -- Órgano (aplanado)
+  nivel1 TEXT,
+  nivel2 TEXT,
+  nivel3 TEXT,
+  -- Información básica
+  sede_electronica TEXT,
+  codigo_bdns TEXT,
+  fecha_recepcion DATE,
+  -- Instrumentos y tipo
+  instrumentos JSONB,
+  tipo_convocatoria TEXT,
+  presupuesto_total NUMERIC,
   mrr BOOLEAN,
   descripcion TEXT,
   descripcion_leng TEXT,
-  fecha_recepcion DATE,
-  nivel1 VARCHAR(255),
-  nivel2 VARCHAR(255),
-  nivel3 VARCHAR(255),
-  codigo_invente VARCHAR(255)
+  -- Beneficiarios y sectores
+  tipos_beneficiarios JSONB,
+  sectores JSONB,
+  regiones JSONB,
+  -- Finalidad y bases reguladoras
+  descripcion_finalidad TEXT,
+  descripcion_bases_reguladoras TEXT,
+  url_bases_reguladoras TEXT,
+  -- Publicación y estado
+  se_publica_diario_oficial BOOLEAN,
+  abierto BOOLEAN,
+  -- Fechas de solicitud
+  fecha_inicio_solicitud DATE,
+  fecha_fin_solicitud DATE,
+  text_inicio TEXT,
+  text_fin TEXT,
+  -- Ayuda de estado
+  ayuda_estado TEXT,
+  url_ayuda_estado TEXT,
+  -- Fondos y reglamento
+  fondos JSONB,
+  reglamento JSONB,
+  -- Objetivos y sectores productos
+  objetivos JSONB,
+  sectores_productos JSONB,
+  -- Documentos y anuncios
+  documentos JSONB,
+  anuncios JSONB,
+  -- Advertencia
+  advertencia TEXT
 );


### PR DESCRIPTION
## Summary

**Qué cambió**: Se normalizó la tabla `l0.nacional_subvenciones` convirtiendo campos JSONB anidados en estructuras tipadas (FK, arrays), y obteniendo todos los datos detallados (32 campos).

**Por qué**: Mejorar rendimiento de consultas (índices GIN en arrays vs queries JSONB), integridad referencial con tablas dimensionales, y facilitar análisis con datos estructurados.

**Cambios principales**:

1. **Normalización de schema**:
   - `instrumentos` JSONB → `instrumento_id SMALLINT` (ref: `dim.instrumentos_subvenciones`)
   - `tipos_beneficiarios` JSONB → `SMALLINT[]` (ref: `dim.beneficiarios_subvenciones`)
   - `sectores` JSONB → `VARCHAR(10)[]` códigos CNAE (ref: `dim.cnae_dim`)
   - `regiones` JSONB → `VARCHAR(10)[]` códigos NUT (ref: `dim.nuts_spain`)
   - `reglamento` JSONB → `TEXT`, `objetivos` JSONB → `TEXT`, arrays vacíos `[]` → `NULL`

2. **Normalización códigos CNAE**:
   - `'96'` → `'96'` (sin cambios)
   - `'96.4'` → `'9640'` (quita punto, añade 0 si solo 3 dígitos)
   - `'96.18'` → `'9618'` (quita punto)

3. **Optimizaciones**:
   - Índices GIN en arrays para búsquedas eficientes
   - Cachés en memoria para mapeos BD (instrumentos, beneficiarios)
   - Rate limiting adaptativo global (0ms → 25ms → ×1.6 exponencial, thread-safe)
   - ThreadPool producer-consumer para fetching + saving paralelo
   - Carga paralela parquets (ThreadPool 3 workers)
   - Consulta optimizada: `ORDER BY id DESC LIMIT 1` en lugar de `MAX(fecha_recepcion)` (250x más rápido)

4. **Nuevo flujo 2 fases**:
   - Fase 1: Obtener IDs ligeros (`/busqueda`)
   - Fase 2: Para cada ID obtener detalles completos (`/convocatorias`)
   - Consolidación: Eliminados endpoint `/ultimas`, clase `LatestParams`, clase `RateLimiter`. Unificado todo en `/busqueda` con parámetro `direccion`

**Archivos modificados**:

- `schemas/012_nacional_subvenciones.sql`: Schema normalizado
- `nacional/subvenciones.py`: Funciones extracción/mapeo, normalización CNAE
- `etl/ingest_l0.py`: `SUBVENCIONES_PARQUET_COLUMNS` actualizado
- `etl/cli.py`: ThreadPool para carga paralela parquets

**Tablas dimensionales**: `dim.instrumentos_subvenciones`, `dim.beneficiarios_subvenciones`, `dim.cnae_dim`, `dim.nuts_spain`

## Linked Issue

Closes #34

## Validation

- [x] Tests de integración: 608/608 registros insertados correctamente (100% éxito)
- [x] Rate limiting funciona sin HTTP 429
- [x] Throughput: ~7 conv/s (~0.15s por convocatoria)
- [x] Multithreading sin race conditions
- [x] Manejo correcto errores SSL transitorios
- [x] Validación en Docker: `licitia-etl ingest nacional subvenciones --anos 2026-2026`

## Risk and Rollback

**Risk level**: High

**Razones**:

- BREAKING CHANGE: Schema incompatible (JSONB → estructuras tipadas)
- Requiere migración manual y reingestión completa de datos
- Cambio arquitectural profundo (de 1 fase a 2 fases)

**Rollback plan**:

1. Revertir commit de esta PR
2. Restaurar schema anterior:
   ```sql
   DROP TABLE l0.nacional_subvenciones;
   -- Ejecutar schema anterior
   ```
3. Restaurar backup de datos si existe
4. Si no hay backup: Reingestar con versión anterior del código

**Migración requerida**:

```sql
-- 1. Borrar datos antiguos
TRUNCATE TABLE l0.nacional_subvenciones;

-- 2. Aplicar nuevo schema
DROP TABLE IF EXISTS l0.nacional_subvenciones;
-- Ejecutar schemas/012_nacional_subvenciones.sql
```

```bash
# 3. Reingestar datos
docker compose exec etl licitia-etl ingest nacional subvenciones --anos 2024-2026
```

**Notas**:

- Proceso de migración puede tardar horas (~0.15seg/convocatoria). Por ejemplo, desde 2024-2026 (~6.6h estimado)
- API externa tiene rate limit que no funciona por ventana, sino por velocidad instantánea/concurrencia. Rate limiting adaptativo busca el menor tiempo de espera posible
- Velocidad de ingesta varía según procesador y red de la máquina
