### PR TITLE
feat(schemas): dim.codigos_ine — municipios INE con FK a NUTS3 (G2)

### DIFF
--- a/schemas/024_dim_codigos_ine.sql
+++ b/schemas/024_dim_codigos_ine.sql
@@ -1,0 +1,29 @@
+-- Tabla de municipios españoles con su correspondencia NUTS3 (nivel provincial).
+-- Fuente oficial: INE — Relación de municipios y sus códigos por provincias.
+-- https://www.ine.es/daco/daco42/codmun/codmunmapa.htm
+--
+-- Propósito: resolver el requisito geográfico G2 ("centro de trabajo en la región")
+-- sin que el servicio consumidor deba implementar un algoritmo INE↔NUTS.
+-- El onboarding registra el CodigoINE del municipio; la FK provee el NUTS3
+-- directamente, que es el eje de matching contra regiones[] de convocatorias.
+--
+-- Diseño:
+--   · codigo_ine  — código INE de 5 dígitos (PK natural, estable).
+--   · municipio   — nombre oficial del municipio según INE.
+--   · nuts3       — FK a dim.nuts_spain(geocode), nivel provincial (ES111..ES703).
+--                   El NUTS2 y NUTS1 se derivan por truncación cuando se necesitan.
+--
+-- Datos: ~8.131 municipios. Poblar mediante script de ingesta desde INE.
+-- Los datos NO se incluyen en este DDL snapshot; se cargan como migración de datos
+-- separada para mantener el fichero de contrato DDL limpio y testeable.
+
+CREATE TABLE IF NOT EXISTS dim.codigos_ine (
+    codigo_ine  VARCHAR(5)  PRIMARY KEY,
+    municipio   TEXT        NOT NULL,
+    nuts3       VARCHAR(10) NOT NULL REFERENCES dim.nuts_spain(geocode)
+);
+
+-- Índice sobre nuts3 para queries de matching geográfico:
+-- «dame todos los municipios que pertenecen al NUTS3 X»
+CREATE INDEX IF NOT EXISTS idx_codigos_ine_nuts3
+ON dim.codigos_ine (nuts3);


### PR DESCRIPTION
Closes #44

## Resumen

Añade \`dim.codigos_ine\` como DDL snapshot en \`schemas/024_dim_codigos_ine.sql\`.

### Motivación — requisito geográfico G2

Resuelve el lookup INE→NUTS3 sin que el servicio de onboarding implemente un algoritmo propio:
- Antes: CodigoINE → algoritmo propio → CodigoNUTS3
- Ahora: CodigoINE → FK dim.codigos_ine → nuts3 (directo)

### Diseño

| Columna | Tipo | Descripción |
|---|---|---|
| codigo_ine | VARCHAR(5) PK | Código INE 5 dígitos (CPRO+CMUN) |
| municipio | TEXT NOT NULL | Nombre oficial INE |
| nuts3 | VARCHAR(10) FK | FK a dim.nuts_spain(geocode) — nivel provincial |

FK activa a dim.nuts_spain — rechaza NUTS3 no existentes en la dimensión.

### Seed de datos

8.132 municipios (INE diccionario26.xlsx, vigente 1-ene-2026) cargados mediante 011_seed_codigos_ine.sql en el migrator del monorepo.