### PR TITLE
Añadir códigos no oficiales de islas en dim.nuts_spain

### DIFF
--- a/schemas/004_nuts_spain.sql
+++ b/schemas/004_nuts_spain.sql
@@ -86,4 +86,16 @@ INSERT INTO dim.nuts_spain (geocode, etiqueta) VALUES
 ('ES640', 'Melilla'),
 ('ES701', 'Las Palmas'),
 ('ES702', 'Santa Cruz de Tenerife')
+-- Códigos NO oficiales pero necesarios para mapeo de nombres exactos de islas Canarias y Baleares
+('ES704', 'Gran Canaria'),
+('ES705', 'Gran Canaria'),
+('ES706', 'Lanzarote'),
+('ES707', 'Fuerteventura'),
+('ES708', 'La Palma'),
+('ES709', 'La Gomera'),
+('ES70A', 'El Hierro'),
+('ES70B', 'Tenerife'),
+('ES531', 'Mallorca'),
+('ES532', 'Menorca'),
+('ES533', 'Eivissa y Formentera')
 ON CONFLICT (geocode) DO NOTHING;


### PR DESCRIPTION
## Summary

**Qué cambió**: Se añaden 13 filas a `dim.nuts_spain` con códigos de islas usados por el SVG del frontend (Canarias y Baleares).

**Por qué**: El SVG no tiene granularidad de provincias en archipiélagos, usa códigos propios por isla. Sin estas filas el nombre no se renderiza.

**Cambios principales**:

1. **`schemas/004_nuts_spain.sql`**: Nuevas filas al final del INSERT (`ES704`–`ES70B` para Canarias, `ES531`–`ES533` para Baleares).

**Archivos modificados**:

- `schemas/004_nuts_spain.sql`

## Linked Issue

Closes #45 

## Validation

- [ ] Verificar que el SVG muestra correctamente los nombres de las islas en el frontend

## Risk and Rollback

**Risk level**: Muy bajo — solo INSERTs nuevos con `ON CONFLICT DO NOTHING`, sin breaking changes.

**Rollback**:

```sql
DELETE FROM dim.nuts_spain
WHERE geocode IN ('ES704','ES705','ES706','ES707','ES708','ES709','ES70A','ES70B','ES531','ES532','ES533');
```
