### PR TITLE
Añadido índice para estado_code

### DIFF
--- a/scripts/create_indexes_l0_nacional.sql
+++ b/scripts/create_indexes_l0_nacional.sql
@@ -5,6 +5,9 @@
 CREATE INDEX IF NOT EXISTS idx_nacional_licitaciones_org_key
   ON l0.nacional_licitaciones ("expediente", "id_plataforma");
 
+CREATE INDEX IF NOT EXISTS idx_nacional_licitaciones_estado_code
+  ON l0.nacional_licitaciones (estado_code);
+
 CREATE INDEX IF NOT EXISTS idx_nacional_agregacion_ccaa_org_key
   ON l0.nacional_agregacion_ccaa ("expediente", "id_plataforma");
 


### PR DESCRIPTION
## Summary
**Qué cambió**: Se añade un índice B-tree sobre `estado_code` en `l0.nacional_licitaciones`.

**Por qué**: Las consultas que filtran por estado realizaban seq scan. Con el índice se acelera ese filtrado ya que se accede siempre a estas columnas.

**Cambios principales**:

1. **`scripts/create_indexes_l0_nacional.sql`**: Nueva sentencia `idx_nacional_licitaciones_estado_code`.

## Linked Issue (required)
Closes #50 

## Validation
- [X] Verificar con `EXPLAIN ANALYZE` que las consultas con `WHERE estado_code = ...` usan el índice.

## Risk and Rollback
**Risk level**: Muy bajo — solo un `CREATE INDEX IF NOT EXISTS`, sin breaking changes.

**Rollback**:

```sql
DROP INDEX IF EXISTS l0.idx_nacional_licitaciones_estado_code;
```
