### PR TITLE
Creada jerarquía en cnae con nuevo atributo

### DIFF
--- a/etl/cnae_ingest.py
+++ b/etl/cnae_ingest.py
@@ -2,9 +2,9 @@
 
 import logging
 import os
+import re
 
 import psycopg2
-from psycopg2 import sql
 import requests
 
 logger = logging.getLogger("etl.cnae_ingest")
@@ -53,18 +53,48 @@ def _extract_label_es(name_block: dict | None) -> str | None:
     return texts[0].get("value") if texts else None
 
 
-def _extract_codes(raw_codes: list[dict]) -> list[tuple[str, str]]:
-    """Return (code, label) tuples for all CNAE codes with a Spanish label."""
-    result = []
+def _is_official_code(code_id: str) -> bool:
+    """Return True only for official CNAE codes: single uppercase letter (section)
+    or digits-only (division/group/class). Excludes aggregates like _T, _N, etc."""
+    return bool(re.match(r"^[A-Z]$", code_id) or re.match(r"^\d+$", code_id))
+
+
+def _build_rows(raw_codes: list[dict]) -> list[tuple[int, str, str, int | None]]:
+    """Build (id, code, label, parent_id) rows with manually assigned sequential IDs.
+
+    The API returns codes in hierarchical order (section letter, then 2-digit, 3-digit,
+    4-digit), so parent_id is resolved by tracking the last assigned id per level:
+      level 1 = single letter (A-U)
+      level 2 = 2-digit code
+      level 3 = 3-digit code
+      level 4 = 4-digit code
+    A code of N digits has parent = last id seen at level N-1.
+    """
+    rows: list[tuple[int, str, str, int | None]] = []
+    counter = 1
+    last_id_by_level: dict[int, int] = {}
+
     for item in raw_codes:
         code_id = item.get("id", "")
-        if not code_id:
+        if not _is_official_code(code_id):
             continue
         label = _extract_label_es(item.get("name"))
         if not label:
             continue
-        result.append((code_id, label))
-    return result
+
+        counter += 1
+
+        if re.match(r"^[A-Z]$", code_id):
+            level = 1
+            parent_id = None
+        else:
+            level = len(code_id)  # 2, 3 or 4
+            parent_id = last_id_by_level.get(level - 1)
+
+        last_id_by_level[level] = counter
+        rows.append((counter, code_id, label, parent_id))
+
+    return rows
 
 
 def run_cnae_ingest(url: str | None = None) -> dict:
@@ -82,25 +112,25 @@ def run_cnae_ingest(url: str | None = None) -> dict:
     logger.info("CNAE ingest: fetching from %s", source_url)
 
     raw_codes = _fetch_all_codes(source_url)
-    codes = _extract_codes(raw_codes)
-    logger.info("CNAE ingest: %d codes extracted", len(codes))
+    rows = _build_rows(raw_codes)
+    logger.info("CNAE ingest: %d codes extracted", len(rows))
 
-    if not codes:
+    if not rows:
         return {"ok": True, "rows": 0, "message": "No CNAE codes found in API response"}
 
     conn = psycopg2.connect(db_url)
     try:
         conn.autocommit = False
-        upsert = sql.SQL(
-            "INSERT INTO dim.cnae_dim (code, label) VALUES (%s, %s) "
-            "ON CONFLICT (code) DO UPDATE SET label = EXCLUDED.label"
+        upsert = (
+            "INSERT INTO dim.cnae_dim (id, code, label, parent_id) VALUES (%s, %s, %s, %s) "
+            "ON CONFLICT (code) DO UPDATE SET label = EXCLUDED.label, parent_id = EXCLUDED.parent_id"
         )
         with conn.cursor() as cur:
-            for code, label in codes:
-                cur.execute(upsert, (code, label))
+            cur.executemany(upsert, rows)
+
         conn.commit()
-        logger.info("CNAE ingest: upserted %d codes into dim.cnae_dim", len(codes))
-        return {"ok": True, "rows": len(codes), "message": f"Upserted {len(codes)} CNAE codes"}
+        logger.info("CNAE ingest: upserted %d codes into dim.cnae_dim", len(rows))
+        return {"ok": True, "rows": len(rows), "message": f"Upserted {len(rows)} CNAE codes"}
     except Exception as e:
         conn.rollback()
         logger.exception("CNAE ingest failed")

--- a/etl/cnae_ingest.py
+++ b/etl/cnae_ingest.py
@@ -11,14 +11,14 @@ logger = logging.getLogger("etl.cnae_ingest")
 
 DEFAULT_CNAE_URL = (
     "https://datos.canarias.es/api/estadisticas/structural-resources/v1.0"
-    "/codelists/ISTAC/CL_CNAE_2025/01.001/codes.json"
+    + "/codelists/ISTAC/CL_CNAE_2025/01.001/codes.json"
 )
 
 PAGE_SIZE = 500
 
 
 def _get_cnae_url() -> str:
-    return os.environ.get("CNAE_SOURCE_URL", "").strip() or DEFAULT_CNAE_URL
+    return DEFAULT_CNAE_URL
 
 
 def _fetch_all_codes(base_url: str) -> list[dict]:
@@ -71,7 +71,7 @@ def _build_rows(raw_codes: list[dict]) -> list[tuple[int, str, str, int | None]]
     A code of N digits has parent = last id seen at level N-1.
     """
     rows: list[tuple[int, str, str, int | None]] = []
-    counter = 1
+    counter = 0
     last_id_by_level: dict[int, int] = {}
 
     for item in raw_codes:

--- a/etl/cnae_ingest.py
+++ b/etl/cnae_ingest.py
@@ -18,7 +18,7 @@ PAGE_SIZE = 500
 
 
 def _get_cnae_url() -> str:
-    return DEFAULT_CNAE_URL
+    return os.environ.get("CNAE_SOURCE_URL", "").strip() or DEFAULT_CNAE_URL
 
 
 def _fetch_all_codes(base_url: str) -> list[dict]:
@@ -59,20 +59,33 @@ def _is_official_code(code_id: str) -> bool:
     return bool(re.match(r"^[A-Z]$", code_id) or re.match(r"^\d+$", code_id))
 
 
+def _extract_parent_letter(item: dict) -> str | None:
+    """Extract the section letter from the SDMX parent URN, e.g. '...CL_CNAE_2025(01.001).A' → 'A'."""
+    parent_urn = item.get("parent", "")
+    if not parent_urn:
+        return None
+    candidate = parent_urn.rsplit(".", 1)[-1]
+    return candidate if re.match(r"^[A-Z]$", candidate) else None
+
+
 def _build_rows(raw_codes: list[dict]) -> list[tuple[int, str, str, int | None]]:
     """Build (id, code, label, parent_id) rows with manually assigned sequential IDs.
 
-    The API returns codes in hierarchical order (section letter, then 2-digit, 3-digit,
-    4-digit), so parent_id is resolved by tracking the last assigned id per level:
-      level 1 = single letter (A-U)
-      level 2 = 2-digit code
-      level 3 = 3-digit code
-      level 4 = 4-digit code
-    A code of N digits has parent = last id seen at level N-1.
+    The API delivers numeric codes first (ordered by depth: 2→3→4 digits) and
+    section letters at the end, so parent_id for 2-digit codes cannot be resolved
+    inline. Strategy:
+      - Single-letter sections  → insert with parent_id=None, record id in section_ids.
+      - 2-digit codes           → insert with parent_id=None, record (row_index, letter)
+                                   in `deferred` for a patch after the main loop.
+      - 3/4-digit codes         → parent resolved inline via last_id_by_level (numeric
+                                   codes come in depth order so the parent is always seen first).
+    The deferred patch is a micro-loop over only ~88 two-digit codes.
     """
     rows: list[tuple[int, str, str, int | None]] = []
     counter = 0
-    last_id_by_level: dict[int, int] = {}
+    last_id_by_level: dict[int, int] = {}  # level → last assigned id
+    section_ids: dict[str, int] = {}  # letter → assigned id
+    deferred: list[tuple[int, str]] = []  # (row_index, section_letter) for 2-digit codes
 
     for item in raw_codes:
         code_id = item.get("id", "")
@@ -87,12 +100,29 @@ def _build_rows(raw_codes: list[dict]) -> list[tuple[int, str, str, int | None]]
         if re.match(r"^[A-Z]$", code_id):
             level = 1
             parent_id = None
+            section_ids[code_id] = counter
+        elif len(code_id) == 2:
+            level = 2
+            parent_id = None  # patched below
+            letter = _extract_parent_letter(item)
+            if letter:
+                deferred.append((len(rows), letter))
+            last_id_by_level[level] = counter
         else:
-            level = len(code_id)  # 2, 3 or 4
+            level = len(code_id)  # 3 or 4
             parent_id = last_id_by_level.get(level - 1)
+            last_id_by_level[level] = counter
 
-        last_id_by_level[level] = counter
         rows.append((counter, code_id, label, parent_id))
+
+    # Patch parent_id for 2-digit codes now that all section ids are known
+    for row_index, letter in deferred:
+        section_id = section_ids.get(letter)
+        if section_id is None:
+            logger.warning("CNAE build_rows: section %r not found for row %d", letter, row_index)
+            continue
+        id_, code, label, _ = rows[row_index]
+        rows[row_index] = (id_, code, label, section_id)
 
     return rows
 

--- a/schemas/013_dim_cnae.sql
+++ b/schemas/013_dim_cnae.sql
@@ -11,4 +11,6 @@ CREATE TABLE IF NOT EXISTS dim.cnae_dim (
     parent_id INTEGER
 );
 
-COMMENT ON COLUMN dim.cnae_dim.parent_id IS 'Referencia lógica a dim.cnae_dim(id). NULL para secciones raíz (nivel 1, código de una letra). Permite reconstruir la jerarquía CNAE desde nivel 4 hasta nivel 1.';
+COMMENT ON COLUMN dim.cnae_dim.parent_id IS 'Referencia lógica a dim.cnae_dim(id). 
+NULL para secciones raíz (nivel 1, código de una letra). Permite reconstruir la jerarquía
+CNAE desde nivel 4 hasta nivel 1.';

--- a/schemas/013_dim_cnae.sql
+++ b/schemas/013_dim_cnae.sql
@@ -5,6 +5,10 @@
 CREATE SCHEMA IF NOT EXISTS dim;
 
 CREATE TABLE IF NOT EXISTS dim.cnae_dim (
-    code    VARCHAR(8) PRIMARY KEY,
-    label   TEXT NOT NULL
+    id        SERIAL PRIMARY KEY,
+    code      VARCHAR(8) NOT NULL UNIQUE,
+    label     TEXT NOT NULL,
+    parent_id INTEGER
 );
+
+COMMENT ON COLUMN dim.cnae_dim.parent_id IS 'Referencia lógica a dim.cnae_dim(id). NULL para secciones raíz (nivel 1, código de una letra). Permite reconstruir la jerarquía CNAE desde nivel 4 hasta nivel 1.';


### PR DESCRIPTION
## Summary
**Qué cambió**: La tabla `dim.cnae_dim` ahora tiene `id SERIAL PRIMARY KEY` y `parent_id INTEGER` para representar la jerarquía oficial CNAE-2025 (sección → división → grupo → clase). El ingest calcula los ids y relaciones en memoria, sin queries extra a BD.

**Por qué**: Sin jerarquía era imposible navegar de un código de nivel 4 hasta su sección sin lógica ad-hoc sobre el texto. Esto bloqueaba agrupaciones y filtros por rama de actividad en licitaciones.

**Cambios principales**:

1. **`schemas/013_dim_cnae.sql`**:
   - `id SERIAL PRIMARY KEY` (nuevo).
   - `code VARCHAR(8) NOT NULL UNIQUE` (deja de ser PK).
   - `parent_id INTEGER` — FK lógica a `dim.cnae_dim(id)`, `NULL` para secciones raíz.
   - `COMMENT ON COLUMN dim.cnae_dim.parent_id` — visible en HeidiSQL/DBeaver/pgAdmin.

2. **`etl/cnae_ingest.py`**:
   - `_is_official_code`: descarta agregados no-oficiales (`_T`, `_N`, `_O`, `_U`, `_X`, `_Z`).
   - `_extract_parent_letter`: extrae la letra de sección del URN SDMX para códigos de 2 dígitos.
   - `_build_rows`: asigna IDs con contador manual y resuelve `parent_id` en memoria en dos fases:
     - 3/4 dígitos → inline con `last_id_by_level` (orden garantizado por la API).
     - 2 dígitos → deferred list (~88 entradas) parchada al final del bucle, una vez conocidos los ids de todas las secciones.
   - `run_cnae_ingest`: un único `executemany` con todos los `(id, code, label, parent_id)` ya resueltos.

**Archivos modificados**:

- `schemas/013_dim_cnae.sql`
- `etl/cnae_ingest.py`

## Linked Issue (required)
Closes #52 

## Validation
- [X] `docker compose exec etl licitia-etl init-db` aplica el schema sin errores.
- [X] `docker compose exec etl licitia-etl cnae ingest` inserta ~1038 códigos.
- [X] Secciones A–U tienen `parent_id = NULL`.
- [X] Código `01` tiene `parent_id` apuntando al id de `A`.
- [X] Código `011` tiene `parent_id` apuntando al id de `01`.
- [X] Código `0111` tiene `parent_id` apuntando al id de `011`.
- [X] No existen filas con `id` como código (`_T`, `_N`, etc.).

```sql
-- Verificación rápida de jerarquía
SELECT c.code, c.label, p.code AS parent_code
FROM dim.cnae_dim c
LEFT JOIN dim.cnae_dim p ON p.id = c.parent_id
WHERE c.code IN ('A', '01', '011', '0111')
ORDER BY c.code;
```

## Risk and Rollback
**Risk level**: Low — solo afecta a `dim.cnae_dim`, tabla de dimensión sin dependencias de FK en otras tablas.

**Rollback**: `DROP TABLE dim.cnae_dim` + `licitia-etl init-db` para recrear con schema anterior.