### PR TITLE
Mejora estado code con entero para mayor eficiencia de acceso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Todos los cambios notables del CLI y del microservicio ETL se documentan aquí.
 
+## [Unreleased]
+
+### Añadido
+
+- **`dim.estado_licitacion` (lookup table de estados)** (`schemas/025_dim_estado_licitacion.sql`): tabla dimensional estática con `id SMALLSERIAL PK`, `code VARCHAR(4) UNIQUE` y `label TEXT`. Seed con los 6 estados PLACSP: `PUB` Publicada, `PRE` Anuncio Previo, `EV` En evaluación, `ADJ` Adjudicada, `RES` Resuelta, `ANUL` Anulada. El label de `PRE` («Anuncio Previo») elimina la necesidad del CASE SQL correctivo que compensaba el valor vacío devuelto por la API original.
+
+### Modificado
+
+- **`l0.nacional_licitaciones.estado_code`**: cambiado de `TEXT` a `SMALLINT` FK referenciando `dim.estado_licitacion.id`. Permite filtrado por estado más eficiente en memoria.
+- **`l0.nacional_licitaciones.estado`** (columna eliminada): la etiqueta legible pasa a obtenerse mediante JOIN con `dim.estado_licitacion.label`.
+- **Índice `estado_code`** creado automáticamente por `ensure_l0_table` en tablas nacionales con esa columna (B-tree sobre `SMALLINT`); el script `scripts/create_indexes_l0_nacional.sql` mantiene la sentencia equivalente para entornos sin ingest automático.
+- **`etl/ingest_l0.py`**: durante la ingesta nacional, se carga el lookup `dim.estado_licitacion` (code→id) y se mapea el código de texto del parquet al entero correspondiente antes de insertar en la tabla L0.
+
+---
+
 ## [2.0.4] — 2026-05-12
 
 ### Añadido

--- a/etl/cli.py
+++ b/etl/cli.py
@@ -59,6 +59,7 @@ INIT_MIGRATIONS = (
     "022_nacional_procedimiento_code_integer.sql",
     "023_llm_resumen_logs.sql",
     "024_dim_municipios.sql",
+    "025_dim_estado_licitacion.sql",
 )
 
 BORME_MIGRATIONS = ("010_borme.sql",)

--- a/etl/ingest_l0.py
+++ b/etl/ingest_l0.py
@@ -64,8 +64,7 @@ NACIONAL_PARQUET_COLUMNS = [
     ("subtipo_code", "TEXT"),
     ("procedimiento_code", "INTEGER"),
     ("procedimiento", "TEXT"),
-    ("estado_code", "TEXT"),
-    ("estado", "TEXT"),
+    ("estado_code", "SMALLINT"),
     ("valor_estimado_contrato", "NUMERIC(18,2)"),
     ("importe_sin_iva", "NUMERIC(18,2)"),
     ("importe_con_iva", "NUMERIC(18,2)"),
@@ -673,6 +672,9 @@ def ensure_l0_table(
                 cur.execute(
                     f'CREATE INDEX IF NOT EXISTS {iname} ON {full_table} ("expediente", "id_plataforma")'
                 )
+            if "estado_code" in col_names:
+                iname = f"idx_{table_name}_estado_code"
+                cur.execute(f'CREATE INDEX IF NOT EXISTS {iname} ON {full_table} ("estado_code")')
 
 
 def load_parquet_to_l0(
@@ -791,7 +793,12 @@ def load_parquet_to_l0(
 
     inserted = 0
     total_candidates = 0
+    estado_code_lookup: dict[str, int] = {}
     with psycopg2.connect(db_url) as conn:
+        if is_nacional:
+            with conn.cursor() as cur_dim:
+                cur_dim.execute("SELECT code, id FROM dim.estado_licitacion")
+                estado_code_lookup = {row[0]: row[1] for row in cur_dim.fetchall()}
         with conn.cursor() as cur:
             for start in range(0, len(df), batch_size):
                 batch = df.iloc[start : start + batch_size]
@@ -908,6 +915,9 @@ def load_parquet_to_l0(
                                             vals.append(int(v))
                                     except (TypeError, ValueError):
                                         vals.append(None)
+                                elif c == "estado_code":
+                                    str_code = str(v).strip()
+                                    vals.append(estado_code_lookup.get(str_code))
                                 elif isinstance(v, (list, dict)) or hasattr(v, "tolist"):
                                     vals.append(psycopg2.extras.Json(_convert_numpy_to_python(v)))
                                 else:

--- a/schemas/004_nuts_spain.sql
+++ b/schemas/004_nuts_spain.sql
@@ -85,7 +85,7 @@ INSERT INTO dim.nuts_spain (geocode, etiqueta) VALUES
 ('ES630', 'Ceuta'),
 ('ES640', 'Melilla'),
 ('ES701', 'Las Palmas'),
-('ES702', 'Santa Cruz de Tenerife')
+('ES702', 'Santa Cruz de Tenerife'),
 -- Códigos NO oficiales pero necesarios para mapeo de nombres exactos de islas Canarias y Baleares
 ('ES703', 'El Hierro'),
 ('ES704', 'Fuerteventura'),

--- a/schemas/025_dim_estado_licitacion.sql
+++ b/schemas/025_dim_estado_licitacion.sql
@@ -1,0 +1,19 @@
+-- Tabla dimensional de estados de licitación (lookup estático).
+-- id: SMALLSERIAL PK → referenciado como SMALLINT FK en l0.nacional_licitaciones.estado_code.
+-- code: código original PLACSP (PUB, PRE, EV, ADJ, RES, ANUL).
+-- label: etiqueta legible; sustituye la columna estado (TEXT) que se elimina de l0.
+
+CREATE TABLE IF NOT EXISTS dim.estado_licitacion (
+  id    SMALLSERIAL  PRIMARY KEY,
+  code  VARCHAR(4)   UNIQUE NOT NULL,
+  label TEXT         NOT NULL
+);
+
+INSERT INTO dim.estado_licitacion (code, label) VALUES
+  ('PUB',  'Publicada'),
+  ('PRE',  'Anuncio Previo'),
+  ('EV',   'En evaluación'),
+  ('ADJ',  'Adjudicada'),
+  ('RES',  'Resuelta'),
+  ('ANUL', 'Anulada')
+ON CONFLICT (code) DO NOTHING;


### PR DESCRIPTION
## Summary
**Qué cambió**: Nueva tabla dimensional `dim.estado_licitacion` con los 6 estados PLACSP. `l0.nacional_licitaciones.estado_code` (y equivalentes en el resto de tablas nacionales) pasa de `TEXT` a `SMALLINT` FK; la columna `estado` (etiqueta duplicada) se elimina.

**Por qué**: El campo `estado_code` se usa como filtro en prácticamente todas las queries de la API pero almacenaba un `TEXT` de hasta 4 caracteres en millones de filas. Con `SMALLINT` (2 bytes frente a los ~8-12 del `TEXT`) el índice es más compacto y los filtros más rápidos. La columna `estado` era redundante y además requería una corrección SQL extra para `PRE` (la API origen devuelve vacío para ese código).

**Cambios principales**:

1. **`schemas/025_dim_estado_licitacion.sql`** (nuevo):
   - `id SMALLSERIAL PRIMARY KEY`, `code VARCHAR(4) UNIQUE`, `label TEXT`.
   - Seed: `PUB` Publicada · `PRE` Anuncio Previo · `EV` En evaluación · `ADJ` Adjudicada · `RES` Resuelta · `ANUL` Anulada.
   - `PRE → Anuncio Previo` elimina el CASE SQL correctivo que compensaba el valor vacío de la API.

2. **`etl/ingest_l0.py`**:
   - `NACIONAL_PARQUET_COLUMNS`: `estado_code TEXT` → `SMALLINT`; fila `estado TEXT` eliminada.
   - `ensure_l0_table`: `CREATE INDEX IF NOT EXISTS idx_{table}_estado_code` añadido automáticamente para tablas con esa columna.
   - `load_parquet_to_l0`: carga lookup `dim.estado_licitacion` (code → id) una sola vez antes del bucle; en el procesamiento de cada fila, `estado_code` se resuelve al id entero correspondiente (`NULL` si el code no está en el lookup).

**Archivos modificados**:

- `schemas/025_dim_estado_licitacion.sql`
- `etl/ingest_l0.py`
- `ignored/migrate_estado_code_to_smallint.sql`

## Linked Issue (required)
Closes #56 

## Validation
Todo comprobado, lo he ejecutado desde nuevo incluida las anteriores PR y nada ha dado fallos.

## Risk and Rollback

**Risk level**: Medio — modifica el tipo de columna en tablas L0 con datos en producción. La migración en caliente es transaccional tabla a tabla (cada bloque de la iteración se completa antes de pasar a la siguiente).

**Rollback** (revertir una tabla a TEXT si fuera necesario):

```sql
ALTER TABLE l0.nacional_licitaciones ADD COLUMN estado_code_txt TEXT;
UPDATE l0.nacional_licitaciones l
SET estado_code_txt = d.code
FROM dim.estado_licitacion d WHERE d.id = l.estado_code;
ALTER TABLE l0.nacional_licitaciones DROP COLUMN estado_code;
ALTER TABLE l0.nacional_licitaciones RENAME COLUMN estado_code_txt TO estado_code;
CREATE INDEX IF NOT EXISTS idx_nacional_licitaciones_estado_code
  ON l0.nacional_licitaciones (estado_code);
```
